### PR TITLE
Create Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+    - "3.6"
+install:
+    - pip install -r requirements/test.txt
+    - pip install -e .
+script:
+    - pytest
+
+


### PR DESCRIPTION
- For issue #11 
- pytest on Python 3.6
- No Python 2.7 (for now) because Sympy on Py2.7 has some weird behaviour with unicode encoded strings (see https://github.com/sympy/sympy/issues/8312 and refs. therein)