### PR TITLE
Implement remaining CellML 2.0 tags

### DIFF
--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -318,7 +318,7 @@ def get_nary_relation_callback(sympy_relation):
     """
     Wraps the Sympy binary relation to handle n-ary MathML relations
 
-    :param sympy_relation: handle to binary Sympy relation (Eq, Le, Lt, Ge, Gt)
+    :param sympy_relation: handle for binary Sympy relation (Eq, Le, Lt, Ge, Gt)
     :return: callback used by the apply_handler to handle n-ary relations
     """
     def _wrapper_relational(*expressions):
@@ -326,7 +326,7 @@ def get_nary_relation_callback(sympy_relation):
         if len(expressions) > 2:
             # Convert to multiple Sympy binary relations bundled in an 'And' boolean
             equalities = []
-            for first, second in zip(expressions, expressions[1:]):
+            for first, second in zip(expressions[:-1], expressions[1:]):
                 equalities.append(sympy_relation(first, second))
             return sympy.And(*equalities)
         return sympy_relation(*expressions)
@@ -342,7 +342,7 @@ def simple_operator_handler(node):
 
     handler = getattr(sympy, SIMPLE_MATHML_TO_SYMPY_NAMES[tag_name])
 
-    # Some MathML relations allow chaining but Synpy relations are binary
+    # Some MathML relations allow chaining but Sympy relations are binary operations
     if tag_name in MATHML_NARY_RELATIONS:
         return get_nary_relation_callback(handler)
 

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -48,15 +48,19 @@ def transpile(xml_node):
                 print('Hit text node with text "' + text + '"')
         elif child_node.nodeType == child_node.ELEMENT_NODE:
             # Call the appropriate MathML handler function for this tag
-            name = child_node.tagName
-            if name in HANDLERS:
+            tag_name = child_node.tagName
+            if tag_name in HANDLERS:
                 # If this tag element itself has children
                 if child_node.childNodes:
                     # We want to pass the node to the handler, and it will deal with children
-                    sympy_expressions.append(HANDLERS[name](child_node))
+                    sympy_expressions.append(HANDLERS[tag_name](child_node))
                 else:
-                    # This tag has no children
-                    sympy_expressions.append(HANDLERS[name]())
+                    # The tag has no children
+                    # Trigonometric functions are wrapped in single handler, needs tag name
+                    if HANDLERS[tag_name] == simple_operator_handler:
+                        sympy_expressions.append(simple_operator_handler(tag_name))
+                    else:
+                        sympy_expressions.append(HANDLERS[tag_name]())
             else:
                 # MathML handler function not found for this tag!
                 raise NotImplementedError('No handler for element <%s>' % child_node.tagName)
@@ -81,7 +85,6 @@ def ci_handler(node):
     """
     MathML:  https://www.w3.org/TR/MathML2/chapter4.html#contm.ci
     SymPy: http://docs.sympy.org/latest/modules/core.html#id17
-    TODO: 'type' attribute?
     """
     identifier = node.childNodes[0].data.strip()
     return sympy.Symbol(identifier)
@@ -91,8 +94,26 @@ def cn_handler(node):
     """
     MathML: https://www.w3.org/TR/MathML2/chapter4.html#contm.cn
     SymPy: http://docs.sympy.org/latest/modules/core.html#number
-    TODO: 'type' attribute?
     """
+
+    # If this number is using scientific notation
+    if 'type' in node.attributes:
+        if node.attributes['type'].value == 'e-notation':
+            # A real number may also be presented in scientific notation. Such numbers have two
+            # parts (a mantissa and an exponent) separated by sep. The first part is a real number,
+            # while the second part is an integer exponent indicating a power of the base.
+            # For example, 12.3<sep/>5 represents 12.3 times 105. The default presentation of
+            # this example is 12.3e5.
+            if len(node.childNodes) == 3 and node.childNodes[1].tagName == 'sep':
+                mantissa = float(node.childNodes[0].data.strip())
+                exponent = int(node.childNodes[2].data.strip())
+                return sympy.Float('%fe%d' % (mantissa, exponent))
+            else:
+                raise SyntaxError('Expecting <cn type="e-notation">significand<sep/>exponent</cn>.'
+                                  'Got: ' + node.toxml())
+        raise NotImplementedError('Unimplemented type attribute for <cn>: '
+                                  + node.attributes['type'].value)
+
     number = float(node.childNodes[0].data.strip())
     return sympy.Number(number)
 
@@ -147,22 +168,6 @@ def otherwise_handler(node):
 
 # ARITHMETIC, ALGEBRA AND LOGIC ################################################################
 
-def plus_handler():
-    """
-    MathML: https://www.w3.org/TR/MathML2/chapter4.html#contm.plus
-    n-ary arithmetic operator
-    """
-    return sympy.Add
-
-
-def times_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.times
-    n-ary arithmetic operator
-    """
-    return sympy.Mul
-
-
 def minus_handler():
     """
     https://www.w3.org/TR/MathML2/chapter4.html#contm.minus
@@ -197,30 +202,6 @@ def divide_handler():
     return __wrapped_divide
 
 
-def rem_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.rem
-    binary arithmetic operator
-    """
-    return sympy.Mod
-
-
-def floor_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.floor
-    unary operator
-    """
-    return sympy.floor
-
-
-def abs_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.abs
-    unary arithmetic operator
-    """
-    return sympy.Abs
-
-
 def power_handler():
     """
     https://www.w3.org/TR/MathML2/chapter4.html#contm.power
@@ -236,72 +217,32 @@ def root_handler():
     """
     https://www.w3.org/TR/MathML2/chapter4.html#contm.root
     operator taking qualifiers
-    TODO: implement <degree>
+
+    Nasty:
+    The root element is used to construct roots. The kind of root to be taken is specified by a
+    degree element, which should be given as the second child of the apply element enclosing the
+    root element. Thus, square roots correspond to the case where degree contains the value 2, cube
+    roots correspond to 3, and so on. If no degree is present, a default value of 2 is used.
     """
-    def __wrapped_root(radicand, degree=None):
-        if degree is None:
-            # by default, sqrt
-            return sympy.root(radicand, 2)
-        else:
-            raise NotImplementedError
-            # return sympy.root(b, a)
+    def __wrapped_root(first_argument, second_argument=None):
+        # if no <degree> given, it's sqrt
+        if second_argument is None:
+            return sympy.root(first_argument, 2)
+        return sympy.root(second_argument, first_argument)
     return __wrapped_root
 
 
-# RELATIONS ####################################################################################
-
-def eq_handler():
+def degree_handler(node):
     """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.eq
-    n-ary operator
+    https://www.w3.org/TR/MathML2/chapter4.html#contm.degree
+    Meaning of <degree> depends on context! We implement it for order of <bvar> in <diff> and
+    the kind of root in <root>
     """
-    return sympy.Eq
-
-
-def leq_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.leq
-    """
-    return sympy.Le
-
-
-def lt_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.lt
-    """
-    return sympy.Lt
-
-
-def geq_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.geq
-    n-ary relation
-    """
-    return sympy.Ge
-
-
-def gt_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.gt
-    n-ary relation
-    """
-    return sympy.Gt
-
-
-def and_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.and
-    n-ary operator
-    """
-    return sympy.And
-
-
-def or_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.or
-    n-ary operator
-    """
-    return sympy.Or
+    result = transpile(node)
+    if len(result) != 1:
+        raise ValueError('Expected single value in <degree> tag.'
+                         'Got: ' + node.toxml())
+    return transpile(node)[0]
 
 
 # CALCULUS AND VECTOR CALCULUS #################################################################
@@ -313,7 +254,16 @@ def diff_handler():
     """
     def __wrapped_diff(x_symbol, y_symbol, evaluate=False):
         # dx / dy
-        y_function = sympy.Function(y_symbol.name)  # given by child element <bvar>
+        y_function = sympy.Function(y_symbol.name)
+
+        # if bound variable element <bvar> contains <degree>, argument x_symbol is a list,
+        # otherwise, it is a symbol
+        if isinstance(x_symbol, list) and len(x_symbol) == 2:
+            bound_variable = x_symbol[0]
+            order = int(x_symbol[1])
+            return sympy.Derivative(y_function(bound_variable), bound_variable,
+                                    int(order), evaluate=evaluate)
+
         return sympy.Derivative(y_function(x_symbol), x_symbol, evaluate=evaluate)
     return __wrapped_diff
 
@@ -324,112 +274,137 @@ def bvar_handler(node):
     NASTY: bvar element depends on the context it is being used
     In a derivative, it indicates the variable with respect to which a function is being
     differentiated.
+
+    The bound variable <bvar> can also specify degree. In this case, we'll have two elements
     """
     result = transpile(node)
-    if len(result) > 1:
-        raise NotImplementedError('multiple <bvar> not implemented')
-    return result[0]
+    if len(result) == 1:
+        # Bound variable without specifying degree
+        return result[0]
+    elif len(result) == 2:
+        return result
+    else:
+        raise SyntaxError("Don't know how to handle <bvar> " + node.toxml())
 
 
 # ELEMENTARY CLASSICAL FUNCTIONS ###############################################################
-
-def exp_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.exp
-    unary arithmetic operator
-    """
-    return sympy.exp
-
-
-def ln_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.ln
-    unary calculus operator
-    """
-    return sympy.ln
-
 
 def log_handler():
     """
     https://www.w3.org/TR/MathML2/chapter4.html#contm.log
     operator taking qualifiers or a unary calculus operator
-    TODO: implement <logbase>
     """
-    def __wrapped_log(term, base=None):
-        if base is None:
+    def __wrapped_log(first_element, second_element=None):
+        if second_element is None:
             # if no <logbase> element is present, the base is assumed to be 10
-            return sympy.log(term, 10)
-        else:
-            # return sympy.log(b, a)
-            raise NotImplementedError
+            return sympy.log(first_element, 10)
+
+        # Has <logbase> element, which is the first_element after <log/>
+        return sympy.log(second_element, first_element)
     return __wrapped_log
 
 
-def cos_handler():
+def logbase_handler(node):
     """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.trig
-    unary trigonometric operator
+    Qualifier for <log>
+
+    The log function accepts only the logbase schema. If present, the logbase schema denotes the
+    base with respect to which the logarithm is being taken. Otherwise, the log is assumed to be b
+    ase 10. When used with log, the logbase schema is expected to contain a single child schema;
+    otherwise an error is generated.
+
+    Should be the first element following log, i.e. the second child of the containing apply
+    element.
     """
-    return sympy.cos
+    return transpile(node)[0]
 
 
-def tanh_handler():
+def simple_operator_handler(tag_name):
     """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.trig
-    unary trigonometric operator
-    """
-    return sympy.tanh
+    This function handles simple MathML <tagName> to sympy.Class operators, where no unique handling
+    of tag children etc. is required. The mappings of tagName to sympy class names is in
 
-
-def arccos_handler():
     """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.trig
-    unary trigonometric operator
-    """
-    return sympy.acos
-
-
-# CONSTANT AND SYMBOL ELEMENTS #################################################################
-
-def pi_handler():
-    """
-    https://www.w3.org/TR/MathML2/chapter4.html#contm.pi
-    """
-    return sympy.pi
+    return getattr(sympy, SIMPLE_MATHML_TO_SYMPY_NAMES[tag_name])
 
 
 # END OF MATHML HANDLERS #######################################################################
 
-# Mapping MathML tag element names (keys) to appropriate function for SymPy output (values)
-HANDLERS = {'abs': abs_handler,
-            'and': and_handler,
-            'apply': apply_handler,
-            'arccos': arccos_handler,
-            'bvar': bvar_handler,
-            'ci': ci_handler,
-            'cn': cn_handler,
-            'cos': cos_handler,
-            'diff': diff_handler,
-            'divide': divide_handler,
-            'eq': eq_handler,
-            'exp': exp_handler,
-            'floor': floor_handler,
-            'geq': geq_handler,
-            'gt': gt_handler,
-            'leq': leq_handler,
-            'ln': ln_handler,
-            'log': log_handler,
-            'lt': lt_handler,
-            'math': math_handler,
-            'minus': minus_handler,
-            'or': or_handler,
-            'otherwise': otherwise_handler,
-            'pi': pi_handler,
-            'piece': piece_handler,
-            'piecewise': piecewise_handler,
-            'plus': plus_handler,
-            'power': power_handler,
-            'rem': rem_handler,
-            'root': root_handler,
-            'tanh': tanh_handler,
-            'times': times_handler}
+# These MathML tags map directly to Sympy class and don't require any extra handling
+SIMPLE_MATHML_TO_SYMPY_NAMES = {
+    'abs': 'Abs',
+    'and': 'And',
+    'arccos': 'acos',
+    'arccosh': 'acosh',
+    'arccot': 'acot',
+    'arccoth': 'acoth',
+    'arccsc': 'acsc',
+    'arccsch': 'acsch',
+    'arcsec': 'asec',
+    'arcsech': 'asech',
+    'arcsin': 'asin',
+    'arcsinh': 'asinh',
+    'arctan': 'atan',
+    'arctanh': 'atanh',
+    'ceiling': 'ceiling',
+    'cos': 'cos',
+    'cosh': 'cosh',
+    'cot': 'cot',
+    'coth': 'coth',
+    'csc': 'csc',
+    'csch': 'csch',
+    'eq': 'Eq',
+    'exp': 'exp',
+    'exponentiale': 'E',
+    'false': 'false',
+    'floor': 'floor',
+    'geq': 'Ge',
+    'gt': 'Gt',
+    'infinity': 'oo',
+    'leq': 'Le',
+    'ln': 'ln',
+    'lt': 'Lt',
+    'max': 'Max',
+    'min': 'Min',
+    'neq': 'Ne',
+    'not': 'Not',
+    'notanumber': 'nan',
+    'or': 'Or',
+    'pi': 'pi',
+    'plus': 'Add',
+    'rem': 'Mod',
+    'sec': 'sec',
+    'sech': 'sech',
+    'sin': 'sin',
+    'sinh': 'sinh',
+    'tan': 'tan',
+    'tanh': 'tanh',
+    'times': 'Mul',
+    'true': 'true',
+    'xor': 'Xor',
+}
+
+# Mapping MathML tag element names (keys) to appropriate handler for SymPy output (values)
+# These tags require explicit handling because they have children or context etc.
+HANDLERS = {
+    'apply': apply_handler,
+    'bvar': bvar_handler,
+    'ci': ci_handler,
+    'cn': cn_handler,
+    'degree': degree_handler,
+    'diff': diff_handler,
+    'divide': divide_handler,
+    'log': log_handler,
+    'logbase': logbase_handler,
+    'math': math_handler,
+    'minus': minus_handler,
+    'otherwise': otherwise_handler,
+    'piece': piece_handler,
+    'piecewise': piecewise_handler,
+    'power': power_handler,
+    'root': root_handler
+}
+
+# Add all the tags that can be handled simple_operator_handler
+for tagName in SIMPLE_MATHML_TO_SYMPY_NAMES:
+    HANDLERS[tagName] = simple_operator_handler

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -55,8 +55,8 @@ def transpile(xml_node):
                     # We want to pass the node to the handler, and it will deal with children
                     sympy_expressions.append(HANDLERS[tag_name](child_node))
                 else:
-                    # The tag has no children
-                    # Trigonometric functions are wrapped in single handler, needs tag name
+                    # Tags which are simple mappings to Sypmy classes use the same handler,
+                    # which only needs the tag name as argument
                     if HANDLERS[tag_name] == simple_operator_handler:
                         sympy_expressions.append(simple_operator_handler(tag_name))
                     else:
@@ -322,8 +322,7 @@ def logbase_handler(node):
 def simple_operator_handler(tag_name):
     """
     This function handles simple MathML <tagName> to sympy.Class operators, where no unique handling
-    of tag children etc. is required. The mappings of tagName to sympy class names is in
-
+    of tag children etc. is required.
     """
     return getattr(sympy, SIMPLE_MATHML_TO_SYMPY_NAMES[tag_name])
 

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -261,8 +261,8 @@ def diff_handler():
         if isinstance(x_symbol, list) and len(x_symbol) == 2:
             bound_variable = x_symbol[0]
             order = int(x_symbol[1])
-            return sympy.Derivative(y_function(bound_variable), bound_variable,
-                                    int(order), evaluate=evaluate)
+            return sympy.Derivative(y_function(bound_variable), bound_variable, order,
+                                    evaluate=evaluate)
 
         return sympy.Derivative(y_function(x_symbol), x_symbol, evaluate=evaluate)
     return __wrapped_diff

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -325,10 +325,10 @@ def get_nary_relation_callback(sympy_relation):
         # If the MathML relation is chaining more than 2 expressions
         if len(expressions) > 2:
             # Convert to multiple Sympy binary relations bundled in an 'And' boolean
-            equalities = []
+            relations = []
             for first, second in zip(expressions[:-1], expressions[1:]):
-                equalities.append(sympy_relation(first, second))
-            return sympy.And(*equalities)
+                relations.append(sympy_relation(first, second))
+            return sympy.And(*relations)
         return sympy_relation(*expressions)
     return _wrapper_relational
 
@@ -406,7 +406,7 @@ SIMPLE_MATHML_TO_SYMPY_NAMES = {
 }
 
 # MathML relation elements that are n-ary operators
-MATHML_NARY_RELATIONS = ['eq', 'leq', 'lt', 'geq', 'gt']
+MATHML_NARY_RELATIONS = {'eq', 'leq', 'lt', 'geq', 'gt'}
 
 # Mapping MathML tag element names (keys) to appropriate handler for SymPy output (values)
 # These tags require explicit handling because they have children or context etc.

--- a/tests/test_mathml2sympy.py
+++ b/tests/test_mathml2sympy.py
@@ -157,10 +157,28 @@ class TestParser(object):
                           '</piecewise>',
                           [sympy.Piecewise((0, x < 0.0), (x, True))])
 
-    def test_multiple_equalities(self):
-        self.assert_equal('<apply><eq/><ci>x</ci><cn>1</cn></apply>'
-                          '<apply><eq/><ci>y</ci><cn>2</cn></apply>',
-                          [sympy.Eq(sympy.Symbol('x'), 1), sympy.Eq(sympy.Symbol('y'), 2)])
+        self.assert_equal('<piecewise>'
+                          '<piece><cn>10</cn><apply><gt/><ci>x</ci><cn>0</cn></apply></piece>'
+                          '<piece><cn>20</cn><apply><gt/><ci>x</ci><cn>1</cn></apply></piece>'
+                          '<piece><cn>30</cn><apply><gt/><ci>x</ci><cn>2</cn></apply></piece>'
+                          '<otherwise><cn>0</cn></otherwise>'
+                          '</piecewise>',
+                          [sympy.Piecewise((10, x > 0), (20, x > 1), (30, x > 2), (0, True))])
+
+    def test_multiple_relations(self):
+        from sympy.abc import a, b, c, x, y, z
+        eq_xml = '<apply><eq/><ci>x</ci><ci>y</ci><ci>z</ci><cn>2.0</cn></apply>'
+        lt_xml = '<apply><lt/><ci>a</ci><ci>b</ci><ci>c</ci><cn>2.0</cn></apply>'
+        ge_xml = '<apply><geq/><ci>x</ci><ci>y</ci><ci>z</ci><cn>2.0</cn></apply>'
+
+        self.assert_equal(eq_xml, [sympy.And(sympy.Eq(x, y), sympy.Eq(y, z), sympy.Eq(z, 2.0))])
+        self.assert_equal(lt_xml, [sympy.And(sympy.Lt(a, b), sympy.Lt(b, c), sympy.Lt(c, 2.0))])
+        self.assert_equal(ge_xml, [sympy.And(sympy.Ge(x, y), sympy.Ge(y, z), sympy.Ge(z, 2.0))])
+        self.assert_equal('<apply><and/>%s%s</apply>' % (eq_xml, lt_xml),
+                          [sympy.And(
+                              sympy.And(sympy.Eq(x, y), sympy.Eq(y, z), sympy.Eq(z, 2.0)),
+                              sympy.And(sympy.Lt(a, b), sympy.Lt(b, c), sympy.Lt(c, 2.0))
+                          )])
 
     def test_cellml_namespace(self):
         mathml_xml = '<math xmlns="http://www.w3.org/1998/Math/MathML" ' \


### PR DESCRIPTION
- Fixes #9
- Supports MathML tags in CellML 2.0 spec.
- MathML tags mapping directly to Sympy classes are handled by single handler. Reduces boilerplate code considerably.
- Some more tests added for simple operators