### PR TITLE
Versions in setup.py should not be pinned

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'networkx>=2',
         'pint>=0.8.1',
         'rdflib>=4',
-        'sympy==1.4',
+        'sympy>=1.2',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Just fixing a small issue with the PR updating the sympy version