### PR TITLE
I looked into removing get_symbol_by_cmeta_id from model.py however i…

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -458,12 +458,11 @@ class Model(object):
         # This should be unreachable
         raise ValueError('No free variable set in model.')  # pragma: no cover
 
-    def get_symbol_by_cmeta_id(self, cmeta_id):
+    def _get_symbol_by_cmeta_id(self, cmeta_id):
         """Searches the given graph and returns the symbol for the variable with the
-        given cmeta_id.
+        given cmeta_id. 
+        PLEASE NOTE this does NOT get the oxmeta tag to get that use get_symbol_by_ontology_term("https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata", "cytosolic_calcium_concentration")
         """
-        # TODO: Either add an argument to allow derivative symbols to be fetched, or
-        #      create a separate method for them.
         for v in self.graph:
             if self.graph.nodes[v].get('cmeta_id', '') == cmeta_id:
                 return v
@@ -521,7 +520,7 @@ class Model(object):
                 # TODO This should eventually be implemented
                 raise NotImplementedError(
                     'Non-local annotations are not supported.')
-            symbols.append(self.get_symbol_by_cmeta_id(uri[1:]))
+            symbols.append(self._get_symbol_by_cmeta_id(uri[1:]))
 
         return symbols
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -459,9 +459,10 @@ class Model(object):
         raise ValueError('No free variable set in model.')  # pragma: no cover
 
     def _get_symbol_by_cmeta_id(self, cmeta_id):
-        """Searches the given graph and returns the symbol for the variable with the
-        given cmeta_id. 
-        PLEASE NOTE this does NOT get the oxmeta tag to get that use get_symbol_by_ontology_term("https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata", "cytosolic_calcium_concentration")
+        """Searches the given graph and returns the symbol for the variable with the given cmeta_id.
+        PLEASE NOTE this does NOT get the oxmeta tag to get that use
+        get_symbol_by_ontology_term("https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata",
+                                    "cytosolic_calcium_concentration")
         """
         for v in self.graph:
             if self.graph.nodes[v].get('cmeta_id', '') == cmeta_id:

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -121,21 +121,20 @@ class UnitStore(object):
             self._define_pint_unit(units_name, unit_definition)
 
     def add_preferred_custom_unit_name(self, units_name, unit_attributes):
-        """Set a prefered name for all equivalent custom units. If it does not exist yet, also define a new Pint unit definition to the unit registry
-           please note: not retrospective, assumes you are not adding new expressions to the model. It also does not do any unit conversions, only works on equivalent units with different names
+        """Set a prefered name for all equivalent custom units. If it does not exist yet, also define a new Pint unit
+        definition to the unit registry.
+        PLEASE NOTE: not retrospective, assumes you are not adding new expressions to the model.
+        It also does not do any unit conversions, only works on equivalent units with different names.
         :param units_name: the prefered name for this unit and all units in the model that are equivalent
         :param unit_attributes:
-        """        
+        """
         try:
             self.add_custom_unit(units_name, unit_attributes)
-        except:
-            pass
+        except AssertionError:
+            pass  # Unit already exists, but that is not a problem
         for dummy in list(self.model.dummy_metadata.items()):
             if self.is_unit_equal(dummy[1].units, getattr(self.ureg, units_name)):
-                try:
-                    dummy[1].units = getattr(self.ureg, units_name)
-                except Exception as E:
-                    pass
+                dummy[1].units = getattr(self.ureg, units_name)
 
     def add_base_unit(self, units_name):
         """Define a new base unit in the Pint registry

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -120,6 +120,23 @@ class UnitStore(object):
 
             self._define_pint_unit(units_name, unit_definition)
 
+    def add_preferred_custom_unit_name(self, units_name, unit_attributes):
+        """Set a prefered name for all equivalent custom units. If it does not exist yet, also define a new Pint unit definition to the unit registry
+           please note: not retrospective, assumes you are not adding new expressions to the model. It also does not do any unit conversions, only works on equivalent units with different names
+        :param units_name: the prefered name for this unit and all units in the model that are equivalent
+        :param unit_attributes:
+        """        
+        try:
+            self.add_custom_unit(units_name, unit_attributes)
+        except:
+            pass
+        for dummy in list(self.model.dummy_metadata.items()):
+            if self.is_unit_equal(dummy[1].units, getattr(self.ureg, units_name)):
+                try:
+                    dummy[1].units = getattr(self.ureg, units_name)
+                except Exception as E:
+                    pass
+
     def add_base_unit(self, units_name):
         """Define a new base unit in the Pint registry
         :param units_name:

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -1,0 +1,17 @@
+import pytest
+import os
+import cellmlmanip
+
+OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata"
+
+
+@pytest.fixture
+def model():
+    return cellmlmanip.load_model(os.path.join(os.path.dirname(__file__), 'cellml_files', "test_simple_odes.cellml"))
+
+
+def test_add_preferred_custom_unit_name(model):
+    time_var = model.get_symbol_by_ontology_term(OXMETA, "time")
+    assert str(model.units.summarise_units(time_var)) == "ms"
+    model.units.add_preferred_custom_unit_name('millisecond', [{'prefix': 'milli', 'units': 'second'}])
+    assert str(model.units.summarise_units(time_var)) == "millisecond"


### PR DESCRIPTION
I looked into removing get_symbol_by_cmeta_id from model.py however it is used internally. I added a comment and renamed it to _get_symbol_by_cmeta_id. I also added a new method to units.py: add_preferred_custom_unit_name this emthod allows you to set a preferred name for equivalent units. For example if the model has mV defined but I was to get back "millivolt" instead