### PR TITLE
for chaste code generation I would like to stay closer to order in th…

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -412,6 +412,7 @@ class Model(object):
 
     def get_equations_for(self, symbols, lexicographical_sort=True):
         """Get all equations for given collection of symbols
+        
         lexicographical_sort indicates whether the result will be sorted in lexicographical order"""
         graph = self.get_equation_graph()
         if lexicographical_sort:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -410,10 +410,14 @@ class Model(object):
         self.graph = graph
         return graph
 
-    def get_equations_for(self, symbols):
-        """Get all equations for given collection of symbols"""
+    def get_equations_for(self, symbols, lexicographical_sort=True):
+        """Get all equations for given collection of symbols
+        lexicographical_sort indicates whether the result will be sorted in lexicographical order"""
         graph = self.get_equation_graph()
-        sorted_symbols = nx.lexicographical_topological_sort(graph, key=str)
+        if lexicographical_sort:
+            sorted_symbols = nx.lexicographical_topological_sort(graph, key=str)
+        else:
+            sorted_symbols = nx.topological_sort(graph)
 
         # Create set of symbols for which we require equations
         required_symbols = set()

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -6,6 +6,7 @@ import sympy
 
 from cellmlmanip import load_model
 
+OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
 class TestHodgkin:
     @pytest.fixture(scope="class")
@@ -240,3 +241,21 @@ class TestHodgkin:
             expected = evaluated_derivatives[state_symbol.name]
             actual = evaluated_deriv
             assert float(actual) == pytest.approx(expected)
+
+    def test_get_symbol_by_ontology_term(self, graph, model):
+        membrane_voltage_var = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
+        assert (isinstance(membrane_voltage_var, sympy.symbol.Dummy))
+        assert str(membrane_voltage_var)=="_membrane$V"
+
+    def test_get_equations_for(self, graph, model):
+        # Get equations for membrane_fast_sodium_current both ordered and unordered
+        membrane_fast_sodium_current = model.get_symbol_by_ontology_term(OXMETA, "membrane_fast_sodium_current")
+        equations = model.get_equations_for([membrane_fast_sodium_current])
+        unordered_equations = model.get_equations_for([membrane_fast_sodium_current], False)
+        # There should be 4 in this model
+        assert len(equations) == len(unordered_equations) == 4
+        #Each equation should be both in the ordered and unordered equations
+        for eq in equations:
+            assert(eq in unordered_equations)
+        for eq in unordered_equations:
+            assert(eq in equations)            


### PR DESCRIPTION
for chaste code generation I would like to stay closer to order in the model to stay closer to pycml output, therfore I needed a version of get_equations_for that does not do a lexicographical_sort