### PR TITLE
Unordered get equations for

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -414,7 +414,8 @@ class Model(object):
         """Get all equations for given collection of symbols
 
         Results are sorted in topographical order.
-        Lexicographical_sort indicates whether the result is sorted in lexicographical order first
+        :param symbols: the symbols to get the equations for
+        :param lexicographical_sort: indicates whether the result is sorted in lexicographical order first
         """
         graph = self.get_equation_graph()
         if lexicographical_sort:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -412,8 +412,10 @@ class Model(object):
 
     def get_equations_for(self, symbols, lexicographical_sort=True):
         """Get all equations for given collection of symbols
-        
-        lexicographical_sort indicates whether the result will be sorted in lexicographical order"""
+
+        Results are sorted in topographical order.
+        Lexicographical_sort indicates whether the result is sorted in lexicographical order first
+        """
         graph = self.get_equation_graph()
         if lexicographical_sort:
             sorted_symbols = nx.lexicographical_topological_sort(graph, key=str)

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -412,6 +412,7 @@ class Model(object):
 
     def get_equations_for(self, symbols, lexicographical_sort=True):
         """Get all equations for given collection of symbols
+        
         lexicographical_sort indicates whether the result will be sorted in lexicographical order"""
         graph = self.get_equation_graph()
         if lexicographical_sort:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -410,10 +410,14 @@ class Model(object):
         self.graph = graph
         return graph
 
-    def get_equations_for(self, symbols):
-        """Get all equations for given collection of symbols"""
+    def get_equations_for(self, symbols, lexicographical_sort=True):
+        """Get all equations for given collection of symbols
+        lexicographical_sort indicates whether the result will be sorted in lexicographical order"""
         graph = self.get_equation_graph()
-        sorted_symbols = nx.lexicographical_topological_sort(graph, key=str)
+        if lexicographical_sort:
+            sorted_symbols = nx.lexicographical_topological_sort(graph, key=str)
+        else:
+            sorted_symbols = nx.topological_sort(graph)
 
         # Create set of symbols for which we require equations
         required_symbols = set()

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -257,6 +257,28 @@ class TestHodgkin:
         assert len(equations) == len(unordered_equations) == 4
         # Each equation should be both in the ordered and unordered equations
         for eq in equations:
-            assert(eq in unordered_equations)
+            assert eq in unordered_equations
         for eq in unordered_equations:
-            assert(eq in equations)
+            assert eq in equations
+
+        # Expected equations
+        ref_eq = [sympy.Eq(sympy.Dummy('membrane$E_R'), sympy.numbers.Float(-75.0)),
+                  sympy.Eq(sympy.Dummy('sodium_channel$E_Na'),
+                           sympy.add.Add(sympy.Dummy('membrane$E_R'), sympy.numbers.Float(115.0))),
+                  sympy.Eq(sympy.Dummy('sodium_channel$g_Na'), sympy.numbers.Float(120.0)),
+                  sympy.Eq(sympy.Dummy('sodium_channel$i_Na'),
+                           sympy.Dummy('sodium_channel_m_gate$m') ** 3.0 * sympy.Dummy('sodium_channel$g_Na') *
+                           sympy.Dummy('sodium_channel_h_gate$h') * (sympy.Dummy('membrane$V') -
+                           sympy.Dummy('sodium_channel$E_Na')))
+                  ]
+
+        # Expected ordering for not lexicographical sorted equations
+        unordered_ref_eq = [ref_eq[2], ref_eq[0], ref_eq[1], ref_eq[3]]
+
+        # Check equations against expected equations
+        for i in range(len(equations)):
+            assert str(equations[i]) == str(ref_eq[i])
+
+        # Check not lexicographical sorted equations against expected equations
+        for i in range(len(unordered_equations)):
+            assert str(unordered_equations[i]) == str(unordered_ref_eq[i])

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -6,6 +6,7 @@ import sympy
 
 from cellmlmanip import load_model
 
+OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
 class TestHodgkin:
     @pytest.fixture(scope="class")
@@ -240,3 +241,21 @@ class TestHodgkin:
             expected = evaluated_derivatives[state_symbol.name]
             actual = evaluated_deriv
             assert float(actual) == pytest.approx(expected)
+
+    def test_get_symbol_by_ontology_term(self, graph, model):
+        membrane_voltage_var = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
+        assert (isinstance(membrane_voltage_var, sympy.symbol.Dummy))
+        assert str(membrane_voltage_var)=="_membrane$V"
+
+    def test_get_equations_for(self, graph, model):
+        # Get equations for membrane_fast_sodium_current both ordered and unordered
+        membrane_fast_sodium_current = model.get_symbol_by_ontology_term(OXMETA, "membrane_fast_sodium_current")
+        equations = model.get_equations_for([membrane_fast_sodium_current])
+        unordered_equations = model.get_equations_for([membrane_fast_sodium_current], False)
+        # There should be 4 in this model
+        assert len(equations) == len(unordered_equations) == 4
+        #Each equation should be both in the ordered and unordered equations
+        for eq in equations:
+            assert(eq in unordered_equations)
+        for eq in unordered_equations:
+            assert(eq in equations)            

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -8,6 +8,7 @@ from cellmlmanip import load_model
 
 OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
+
 class TestHodgkin:
     @pytest.fixture(scope="class")
     def model(self):
@@ -245,7 +246,7 @@ class TestHodgkin:
     def test_get_symbol_by_ontology_term(self, graph, model):
         membrane_voltage_var = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
         assert (isinstance(membrane_voltage_var, sympy.symbol.Dummy))
-        assert str(membrane_voltage_var)=="_membrane$V"
+        assert str(membrane_voltage_var) == "_membrane$V"
 
     def test_get_equations_for(self, graph, model):
         # Get equations for membrane_fast_sodium_current both ordered and unordered
@@ -254,8 +255,8 @@ class TestHodgkin:
         unordered_equations = model.get_equations_for([membrane_fast_sodium_current], False)
         # There should be 4 in this model
         assert len(equations) == len(unordered_equations) == 4
-        #Each equation should be both in the ordered and unordered equations
+        # Each equation should be both in the ordered and unordered equations
         for eq in equations:
             assert(eq in unordered_equations)
         for eq in unordered_equations:
-            assert(eq in equations)            
+            assert(eq in equations)


### PR DESCRIPTION
Would like to be able to not get the get_equations_for results in lexicographical_topological order (but only in topological order