### PR TITLE
added input order preservation and exclusion list to get_equations_for

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -439,7 +439,8 @@ class Model(object):
         for output in symbols:
             if output not in required_symbols and output not in excluded_symbols:
                 for p in get_parents(output):
-                    required_symbols.append(p)
+                    if p not in excluded_symbols and p not in required_symbols:
+                        required_symbols.append(p)
 
         eqs = []
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -430,8 +430,7 @@ class Model(object):
                 ancestors.sort(key=str)
                 for a in ancestors:
                     to_process.appendleft(a)
-                if parent not in parents:
-                    parents.insert(0, parent)
+                parents.insert(0, parent)
             return parents
 
         # Create list of symbols for which we require equations (list instead of set, in order to preserve order)
@@ -439,8 +438,7 @@ class Model(object):
         for output in symbols:
             if output not in required_symbols and output not in excluded_symbols:
                 for p in get_parents(output):
-                    if p not in required_symbols:
-                        required_symbols.append(p)
+                    required_symbols.append(p)
 
         eqs = []
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -441,8 +441,6 @@ class Model(object):
                 for p in get_parents(output):
                     if p not in required_symbols:
                         required_symbols.append(p)
-                if output not in required_symbols:
-                    required_symbols.append(output)
 
         eqs = []
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -419,17 +419,20 @@ class Model(object):
         :param excluded_symbols: list of symbols to exlcude
         """
         graph = self.get_equation_graph()
+        sorted_symbols = [s for s in nx.topological_sort(graph)]
 
-        def get_parents(node, graph=graph):
+        def get_parents(node, graph=graph, sorted_symbols=sorted_symbols):
             parents = []
             to_process = deque()
             to_process.appendleft(node)
             while len(to_process) > 0:
                 parent = to_process.popleft()
                 ancestors = [a for a in graph.predecessors(parent)]
-                ancestors.sort(key=str)
-                for a in ancestors:
-                    to_process.appendleft(a)
+                for sym in sorted_symbols:
+                    if sym in ancestors:
+                        #ancestors.sort(key=str)
+                        #for a in ancestors:
+                        to_process.appendleft(sym)
                 parents.insert(0, parent)
             return parents
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -429,8 +429,7 @@ class Model(object):
                 ancestors = [a for a in graph.predecessors(parent)]
                 ancestors.sort(key=str)
                 for a in ancestors:
-                    if a not in parents:
-                        to_process.appendleft(a)
+                    to_process.appendleft(a)
                 if parent not in parents:
                     parents.insert(0, parent)
             return parents

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -1,13 +1,12 @@
 ﻿"""Classes to represent a flattened CellML model and metadata about its variables"""
 import logging
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from io import StringIO
 from typing import Dict, List, Union
 
 import networkx as nx
 import rdflib
 import sympy
-from collections import deque
 
 from cellmlmanip.rdf import create_rdf_node
 from cellmlmanip.units import UnitStore

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -430,8 +430,6 @@ class Model(object):
                 ancestors = [a for a in graph.predecessors(parent)]
                 for sym in sorted_symbols:
                     if sym in ancestors:
-                        #ancestors.sort(key=str)
-                        #for a in ancestors:
                         to_process.appendleft(sym)
                 parents.insert(0, parent)
             return parents

--- a/tests/cellml_files/simple_model_units.cellml
+++ b/tests/cellml_files/simple_model_units.cellml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model name="component_with_units"
+       xmlns="http://www.cellml.org/cellml/1.0#"
+       xmlns:cellml="http://www.cellml.org/cellml/1.0#"
+       xmlns:cmeta="http://www.cellml.org/metadata/1.0#">
+
+    <units name="ms">
+       <unit units="second" prefix="milli"/>
+    </units>
+    <units name="per_ms">
+       <unit units="ms" exponent="-1"/>
+    </units>
+
+    <component name="A">
+        <variable name="a" units="ms" cmeta:id="a"/>
+        <variable name="b" units="per_ms" cmeta:id="b"/>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+                <eq/>
+                <ci>a</ci>
+                <cn cellml:units="ms">1</cn>
+            </apply>
+            <apply>
+                <eq/>
+                <ci>b</ci>
+                <apply>
+                    <divide/>
+                    <cn cellml:units="dimensionless">2</cn>
+                    <ci> a </ci>
+                </apply>
+            </apply>
+        </math>
+    </component>
+</model>

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -283,9 +283,9 @@ class TestHodgkin:
         input_ordered_equations = model.get_equations_for(
             [membrane_fast_sodium_current, membrane_stimulus_current_offset,
              membrane_stimulus_current_offset, membrane_stimulus_current_period],
-            True, [membrane_stimulus_current_period])
+            sort_by_input_symbols=True, excluded_symbols=[membrane_stimulus_current_period])
 
-        # There should be 10 in this model
+        # There should be 5 in this model
         assert len(equations) == len(input_ordered_equations) == 5
         # Each equation should be both in the ordered and unordered equations
         for eq in equations:
@@ -304,7 +304,7 @@ class TestHodgkin:
                            sympy.Dummy('sodium_channel$E_Na')))]
 
         # Expected ordering for not lexicographical sorted equations
-        unordered_ref_eq = [ref_eq[0], ref_eq[2], ref_eq[3], ref_eq[4], ref_eq[1]]
+        unordered_ref_eq = [ref_eq[3], ref_eq[0], ref_eq[2], ref_eq[4], ref_eq[1]]
 
         # Check equations against expected equations
         for i in range(len(equations)):

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -282,7 +282,8 @@ class TestHodgkin:
         equations = model.get_equations_for([membrane_fast_sodium_current, membrane_stimulus_current_offset])
         input_ordered_equations = model.get_equations_for(
             [membrane_fast_sodium_current, membrane_stimulus_current_offset,
-             membrane_stimulus_current_period], True, [membrane_stimulus_current_period])
+             membrane_stimulus_current_offset, membrane_stimulus_current_period],
+            True, [membrane_stimulus_current_period])
 
         # There should be 10 in this model
         assert len(equations) == len(input_ordered_equations) == 5

--- a/tests/test_simple_model_units.py
+++ b/tests/test_simple_model_units.py
@@ -1,0 +1,38 @@
+import os
+
+import pytest
+import sympy
+
+from cellmlmanip import load_model
+
+OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
+
+
+class TestSimpleModelUnitsl:
+    @pytest.fixture(scope="class")
+    def model(self):
+        simple_model_units_cellml = os.path.join(
+            os.path.dirname(__file__),
+            "cellml_files",
+            "simple_model_units.cellml"
+        )
+        return load_model(simple_model_units_cellml)
+
+    def test_get_equations_for(self, model):
+        symbol_a = model.get_symbol_by_cmeta_id("a")
+        symbol_b = model.get_symbol_by_cmeta_id("b")
+        equations = model.get_equations_for([symbol_a, symbol_b], sort_by_input_symbols=False)
+        ordered_equation = model.get_equations_for([symbol_a, symbol_b], sort_by_input_symbols=True)
+        assert(len(ordered_equation) == len(ordered_equation) == 2)
+
+        ref_eq = [sympy.Eq(sympy.Dummy('A$a'), sympy.numbers.Float(1.0)),
+                  sympy.Eq(sympy.Dummy('A$b'), sympy.numbers.Float(2.0) / sympy.Dummy('A$a'))]
+        ordered_ref_eq = ref_eq
+
+        # Check equations against expected equations
+        for i in range(len(equations)):
+            assert str(equations[i]) == str(ref_eq[i])
+
+        # Check equations against expected equations
+        for i in range(len(ordered_equation)):
+            assert str(ordered_equation[i]) == str(ordered_ref_eq[i])


### PR DESCRIPTION
I have had a play with get_equations_for and it's not straightforward to preserve an order resembling the input list due to how the digraph works. 
This way does seem seem to work, although it feels like it can be written up nicer maybe. Specifically it keeps also the original sorting as the default option (hence only acts differently if you provide a flag), not sure if that's useful.

Unfortunately `graph.predecessors(parent)` doesn't always return things in the same order, hence the sorting. 

Also: I'm assuming that if I get predecessors all those don't have any interdependence. I.e. one of the predecessors shouldn't contain another one, as then it should be a parent? If that's not necessarily the case, we would need a more complex sorting.
