### PR TITLE
added functionality to be able to order state variables in the order they were added to the model 

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -457,7 +457,7 @@ class Model(object):
     def get_state_symbols(self, order_by_order_added=False):
         """Returns a list of state variables found in the given model graph.
         order_by_order_added indicates whether state_symbols are sorted in the order they appear in the model
-        (otherwise orderin is determined by the other in equations)
+        (otherwise ordering is determined by the order in equations)
         """
         state_symbols = [v.args[0] for v in self.get_derivative_symbols()]
         if not order_by_order_added:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -89,8 +89,6 @@ class Model(object):
 
         self.equations: List[sympy.Eq] = list()
 
-        self._variable_order_added = -1
-
     def add_unit(self, units_name: str, unit_attributes: List[Dict] = None, base_units=False):
         """Adds information about <units> in <model>
         """
@@ -139,14 +137,13 @@ class Model(object):
         if initial_value is not None:
             initial_value = float(initial_value)
 
-        self._variable_order_added += 1
         variable = MetaDummy(name=name,
                              units=self.units.get_quantity(units),
                              dummy=dummy,
                              initial_value=initial_value,
                              public_interface=public_interface,
                              private_interface=private_interface,
-                             order_added=self._variable_order_added,
+                             order_added=len(self.dummy_metadata),
                              **kwargs)
 
         self.dummy_metadata[dummy] = variable

--- a/tests/cellml_files/aslanidi_model_2009.cellml
+++ b/tests/cellml_files/aslanidi_model_2009.cellml
@@ -1,0 +1,4092 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This CellML file was generated on 21/09/2009 at 15:12:58 using:
+
+COR (0.9.31.1319)
+Copyright 2002-2009 Dr Alan Garny
+http://cor.physiol.ox.ac.uk/ - cor@physiol.ox.ac.uk
+
+CellML 1.0 was used to generate this model
+http://www.cellml.org/
+-->
+<model name="aslanidi_model_2009" cmeta:id="aslanidi_model_2009" xmlns="http://www.cellml.org/cellml/1.0#" xmlns:cellml="http://www.cellml.org/cellml/1.0#" xmlns:cmeta="http://www.cellml.org/metadata/1.0#">
+   <units name="per_second">
+      <unit units="second" exponent="-1"/>
+   </units>
+   <units name="millivolt">
+      <unit units="volt" prefix="milli"/>
+   </units>
+   <units name="per_millivolt">
+      <unit units="millivolt" exponent="-1"/>
+   </units>
+   <units name="per_millivolt_second">
+      <unit units="millivolt" exponent="-1"/>
+      <unit units="second" exponent="-1"/>
+   </units>
+   <units name="millimolar">
+      <unit units="mole" prefix="milli"/>
+      <unit units="litre" exponent="-1"/>
+   </units>
+   <units name="per_millimolar_second">
+      <unit units="millimolar" exponent="-1"/>
+      <unit units="second" exponent="-1"/>
+   </units>
+   <units name="per_millimolar_4">
+      <unit units="millimolar" exponent="-4"/>
+   </units>
+   <units name="picoA_per_millimolar">
+      <unit units="ampere" prefix="pico"/>
+      <unit units="millimolar" exponent="-1"/>
+   </units>
+   <units name="picoA_per_millimolar_4">
+      <unit units="ampere" prefix="pico"/>
+      <unit units="millimolar" exponent="-4"/>
+   </units>
+   <units name="picoA">
+      <unit units="ampere" prefix="pico"/>
+   </units>
+   <units name="nanoS">
+      <unit units="siemens" prefix="nano"/>
+   </units>
+   <units name="nanoF">
+      <unit units="farad" prefix="nano"/>
+   </units>
+   <units name="nanolitre">
+      <unit units="litre" prefix="nano"/>
+   </units>
+   <units name="nanolitre_per_second">
+      <unit units="litre" prefix="nano"/>
+      <unit units="second" exponent="-1"/>
+   </units>
+   <units name="millijoule_per_mole_kelvin">
+      <unit units="joule" prefix="milli"/>
+      <unit units="mole" exponent="-1"/>
+      <unit units="kelvin" exponent="-1"/>
+   </units>
+   <units name="coulomb_per_mole">
+      <unit units="coulomb"/>
+      <unit units="mole" exponent="-1"/>
+   </units>
+   <component name="environment">
+      <variable name="time" units="second" public_interface="out"/>
+      <variable name="CT" units="dimensionless" initial_value="1" public_interface="out"/>
+      <variable name="PM" units="dimensionless" initial_value="0" public_interface="out"/>
+   </component>
+   <component name="membrane">
+      <variable name="V" units="millivolt" initial_value="-80" public_interface="out" cmeta:id="membrane_voltage">
+         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#membrane_voltage">
+               <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_voltage"/>
+            </rdf:Description>
+         </rdf:RDF>
+      </variable>
+      <variable name="R" units="millijoule_per_mole_kelvin" initial_value="8314" public_interface="out"/>
+      <variable name="T" units="kelvin" initial_value="308" public_interface="out"/>
+      <variable name="F" units="coulomb_per_mole" initial_value="96487" public_interface="out"/>
+      <variable name="Cm" units="nanoF" initial_value="0.00005" cmeta:id="Cm">
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+          <rdf:Description rdf:about="#Cm">
+            <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_capacitance"/>
+          </rdf:Description>
+        </rdf:RDF>
+      </variable>
+      <variable name="time" units="second" public_interface="in"/>
+      <variable name="i_Na" units="picoA" public_interface="in"/>
+      <variable name="i_Ca_L" units="picoA" public_interface="in"/>
+      <variable name="i_Ca_T" units="picoA" public_interface="in"/>
+      <variable name="i_to" units="picoA" public_interface="in"/>
+      <variable name="i_sus" units="picoA" public_interface="in"/>
+      <variable name="i_K1" units="picoA" public_interface="in"/>
+      <variable name="i_Kr" units="picoA" public_interface="in"/>
+      <variable name="i_Ks" units="picoA" public_interface="in"/>
+      <variable name="i_B_Na" units="picoA" public_interface="in"/>
+      <variable name="i_B_Ca" units="picoA" public_interface="in"/>
+      <variable name="i_p" units="picoA" public_interface="in"/>
+      <variable name="i_CaP" units="picoA" public_interface="in"/>
+      <variable name="i_NaCa" units="picoA" public_interface="in"/>
+      <variable name="i_Stim" units="picoA" public_interface="out" cmeta:id="membrane_stimulus_current">
+         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#membrane_stimulus_current">
+               <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current"/>
+            </rdf:Description>
+         </rdf:RDF>
+      </variable>
+      <variable name="stim_start" units="second" initial_value="0.01" cmeta:id="membrane_stimulus_current_offset">
+         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#membrane_stimulus_current_offset">
+               <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_offset"/>
+            </rdf:Description>
+         </rdf:RDF>
+      </variable>
+      <variable name="stim_end" units="second" initial_value="100"/>
+      <variable name="stim_period" units="second" initial_value="0.5" cmeta:id="membrane_stimulus_current_period">
+         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#membrane_stimulus_current_period">
+               <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_period"/>
+            </rdf:Description>
+         </rdf:RDF>
+      </variable>
+      <variable name="stim_duration" units="second" initial_value="0.0002" cmeta:id="membrane_stimulus_current_duration">
+         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#membrane_stimulus_current_duration">
+               <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_duration"/>
+            </rdf:Description>
+         </rdf:RDF>
+      </variable>
+      <variable name="stim_amplitude" units="picoA" initial_value="-20" cmeta:id="membrane_stimulus_current_amplitude">
+         <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#membrane_stimulus_current_amplitude">
+               <bqbiol:is rdf:resource="https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#membrane_stimulus_current_amplitude"/>
+            </rdf:Description>
+         </rdf:RDF>
+      </variable>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_Stim</ci>
+            <piecewise>
+               <piece>
+                  <ci>stim_amplitude</ci>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <geq/>
+                        <ci>time</ci>
+                        <ci>stim_start</ci>
+                     </apply>
+                     <apply>
+                        <leq/>
+                        <ci>time</ci>
+                        <ci>stim_end</ci>
+                     </apply>
+                     <apply>
+                        <leq/>
+                        <apply>
+                           <minus/>
+                           <apply>
+                              <minus/>
+                              <ci>time</ci>
+                              <ci>stim_start</ci>
+                           </apply>
+                           <apply>
+                              <times/>
+                              <apply>
+                                 <floor/>
+                                 <apply>
+                                    <divide/>
+                                    <apply>
+                                       <minus/>
+                                       <ci>time</ci>
+                                       <ci>stim_start</ci>
+                                    </apply>
+                                    <ci>stim_period</ci>
+                                 </apply>
+                              </apply>
+                              <ci>stim_period</ci>
+                           </apply>
+                        </apply>
+                        <ci>stim_duration</ci>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <cn cellml:units="picoA">0</cn>
+               </otherwise>
+            </piecewise>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>V</ci>
+            </apply>
+            <apply>
+               <times/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <minus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                  </apply>
+                  <ci>Cm</ci>
+               </apply>
+               <apply>
+                  <plus/>
+                  <ci>i_Kr</ci>
+                  <ci>i_Ks</ci>
+                  <ci>i_Na</ci>
+                  <ci>i_Ca_L</ci>
+                  <ci>i_Ca_T</ci>
+                  <ci>i_to</ci>
+                  <ci>i_sus</ci>
+                  <ci>i_K1</ci>
+                  <ci>i_B_Na</ci>
+                  <ci>i_B_Ca</ci>
+                  <ci>i_p</ci>
+                  <ci>i_CaP</ci>
+                  <ci>i_NaCa</ci>
+                  <ci>i_Stim</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_current">
+      <variable name="i_Na" units="picoA" public_interface="out"/>
+      <variable name="E_Na" units="millivolt" public_interface="out"/>
+      <variable name="P_Na" units="nanolitre_per_second" initial_value="0.0000014"/>
+      <variable name="time" units="second" public_interface="in" private_interface="out"/>
+      <variable name="V" units="millivolt" public_interface="in" private_interface="out"/>
+      <variable name="Na_c" units="millimolar" public_interface="in"/>
+      <variable name="Na_i" units="millimolar" public_interface="in"/>
+      <variable name="R" units="millijoule_per_mole_kelvin" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="T" units="kelvin" public_interface="in"/>
+      <variable name="m" units="dimensionless" private_interface="in"/>
+      <variable name="h1" units="dimensionless" private_interface="in"/>
+      <variable name="h2" units="dimensionless" private_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E_Na</ci>
+            <apply>
+               <times/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <times/>
+                     <ci>R</ci>
+                     <ci>T</ci>
+                  </apply>
+                  <ci>F</ci>
+               </apply>
+               <apply>
+                  <ln/>
+                  <apply>
+                     <divide/>
+                     <ci>Na_c</ci>
+                     <ci>Na_i</ci>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_Na</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <times/>
+                        <ci>P_Na</ci>
+                        <apply>
+                           <power/>
+                           <ci>m</ci>
+                           <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                        <apply>
+                           <plus/>
+                           <apply>
+                              <times/>
+                              <cn cellml:units="dimensionless">0.635</cn>
+                              <ci>h1</ci>
+                           </apply>
+                           <apply>
+                              <times/>
+                              <cn cellml:units="dimensionless">0.365</cn>
+                              <ci>h2</ci>
+                           </apply>
+                        </apply>
+                        <ci>Na_c</ci>
+                        <ci>V</ci>
+                        <apply>
+                           <power/>
+                           <ci>F</ci>
+                           <cn cellml:units="dimensionless">2</cn>
+                        </apply>
+                     </apply>
+                     <apply>
+                        <times/>
+                        <ci>R</ci>
+                        <ci>T</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <times/>
+                              <apply>
+                                 <minus/>
+                                 <ci>V</ci>
+                                 <ci>E_Na</ci>
+                              </apply>
+                              <ci>F</ci>
+                           </apply>
+                           <apply>
+                              <times/>
+                              <ci>R</ci>
+                              <ci>T</ci>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <cn cellml:units="dimensionless">1</cn>
+                  </apply>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <times/>
+                           <ci>V</ci>
+                           <ci>F</ci>
+                        </apply>
+                        <apply>
+                           <times/>
+                           <ci>R</ci>
+                           <ci>T</ci>
+                        </apply>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_current_m_gate">
+      <variable name="m" units="dimensionless" initial_value="0.01309" public_interface="out"/>
+      <variable name="E0_m" units="millivolt"/>
+      <variable name="alpha_m" units="per_second"/>
+      <variable name="beta_m" units="per_second"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E0_m</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">44.4</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>alpha_m</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <apply>
+                     <minus/>
+                     <cn cellml:units="per_millivolt_second">460</cn>
+                  </apply>
+                  <ci>E0_m</ci>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <ci>E0_m</ci>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">12.673</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_m</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">18400</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>E0_m</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">12.673</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>m</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>alpha_m</ci>
+                  <apply>
+                     <minus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <ci>m</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>beta_m</ci>
+                  <ci>m</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_current_h1_gate">
+      <variable name="h1" units="dimensionless" initial_value="0.706" public_interface="out"/>
+      <variable name="alpha_h" units="per_second"/>
+      <variable name="beta_h" units="per_second"/>
+      <variable name="h_infinity" units="dimensionless" public_interface="out"/>
+      <variable name="tau_h1" units="second"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_h</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">44.9</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <plus/>
+                        <ci>V</ci>
+                        <cn cellml:units="millivolt">66.9</cn>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">5.57</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_h</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="per_second">1491</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">323.3</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <plus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">94.6</cn>
+                           </apply>
+                           <apply>
+                              <minus/>
+                              <cn cellml:units="millivolt">12.9</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>h_infinity</ci>
+            <apply>
+               <divide/>
+               <ci>alpha_h</ci>
+               <apply>
+                  <plus/>
+                  <ci>alpha_h</ci>
+                  <ci>beta_h</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_h1</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="second">0.03</cn>
+                  <apply>
+                     <plus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <plus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">40</cn>
+                           </apply>
+                           <cn cellml:units="millivolt">6</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <cn cellml:units="second">0.00015</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>h1</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>h_infinity</ci>
+                  <ci>h1</ci>
+               </apply>
+               <ci>tau_h1</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_current_h2_gate">
+      <variable name="h2" units="dimensionless" initial_value="0.61493" public_interface="out"/>
+      <variable name="tau_h2" units="second"/>
+      <variable name="h_infinity" units="dimensionless" public_interface="in"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>tau_h2</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="second">0.12</cn>
+                  <apply>
+                     <plus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <plus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">60</cn>
+                           </apply>
+                           <cn cellml:units="millivolt">2</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <cn cellml:units="second">0.00045</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>h2</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>h_infinity</ci>
+                  <ci>h2</ci>
+               </apply>
+               <ci>tau_h2</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="L_type_Ca_channel">
+      <variable name="i_Ca_L" units="picoA" public_interface="out"/>
+      <variable name="g_Ca_L" units="nanoS" initial_value="0.004"/>
+      <variable name="E_Ca_app" units="millivolt" initial_value="50"/>
+      <variable name="time" units="second" public_interface="in" private_interface="out"/>
+      <variable name="V" units="millivolt" public_interface="in" private_interface="out"/>
+      <variable name="d_prime" units="dimensionless"/>
+      <variable name="d_L" units="dimensionless" private_interface="in"/>
+      <variable name="f_L" units="dimensionless" private_interface="in"/>
+      <variable name="CT" units="dimensionless" public_interface="in"/>
+      <variable name="PM" units="dimensionless" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>d_prime</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">23</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">12</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_Ca_L</ci>
+            <piecewise>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">1.8</cn>
+                     <ci>g_Ca_L</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <ci>d_L</ci>
+                           <ci>f_L</ci>
+                        </apply>
+                        <ci>d_prime</ci>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Ca_app</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">2.1</cn>
+                     <ci>g_Ca_L</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <ci>d_L</ci>
+                           <ci>f_L</ci>
+                        </apply>
+                        <ci>d_prime</ci>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Ca_app</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <apply>
+                     <times/>
+                     <ci>g_Ca_L</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <ci>d_L</ci>
+                           <ci>f_L</ci>
+                        </apply>
+                        <ci>d_prime</ci>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Ca_app</ci>
+                     </apply>
+                  </apply>
+               </otherwise>
+            </piecewise>
+         </apply>
+      </math>
+   </component>
+   <component name="L_type_Ca_channel_d_L_gate">
+      <variable name="d_L" units="dimensionless" initial_value="0.00003" public_interface="out"/>
+      <variable name="E0_alpha_d_L" units="millivolt"/>
+      <variable name="E0_beta_d_L" units="millivolt"/>
+      <variable name="E10" units="millivolt"/>
+      <variable name="alpha_d_L" units="per_second"/>
+      <variable name="beta_d_L" units="per_second"/>
+      <variable name="d_L_infinity" units="dimensionless"/>
+      <variable name="tau_d_L" units="second"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E0_alpha_d_L</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">45</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>E0_beta_d_L</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">5</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>E10</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">10</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>alpha_d_L</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <times/>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="per_millivolt_second">16.72</cn>
+                     </apply>
+                     <ci>E0_alpha_d_L</ci>
+                  </apply>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <ci>E0_alpha_d_L</ci>
+                           <apply>
+                              <minus/>
+                              <cn cellml:units="millivolt">2.5</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <cn cellml:units="dimensionless">1</cn>
+                  </apply>
+               </apply>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <times/>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="per_millivolt_second">50</cn>
+                     </apply>
+                     <ci>E10</ci>
+                  </apply>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <ci>E10</ci>
+                           <apply>
+                              <minus/>
+                              <cn cellml:units="millivolt">4.808</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <cn cellml:units="dimensionless">1</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_d_L</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millivolt_second">4.48</cn>
+                  <ci>E0_beta_d_L</ci>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <ci>E0_beta_d_L</ci>
+                        <cn cellml:units="millivolt">2.5</cn>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>d_L_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>E10</ci>
+                           <cn cellml:units="millivolt">0.95</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">6.6</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_d_L</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <ci>alpha_d_L</ci>
+                  <ci>beta_d_L</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>d_L</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>d_L_infinity</ci>
+                  <ci>d_L</ci>
+               </apply>
+               <ci>tau_d_L</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="L_type_Ca_channel_f_L_gate">
+      <variable name="f_L" units="dimensionless" initial_value="0.99981" public_interface="out"/>
+      <variable name="E0_f_L" units="millivolt"/>
+      <variable name="alpha_f_L" units="per_second"/>
+      <variable name="beta_f_L" units="per_second"/>
+      <variable name="f_L_infinity" units="dimensionless" public_interface="out"/>
+      <variable name="tau_f_L" units="second"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E0_f_L</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">18</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>alpha_f_L</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millivolt_second">8.49</cn>
+                  <ci>E0_f_L</ci>
+               </apply>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <ci>E0_f_L</ci>
+                        <cn cellml:units="millivolt">4</cn>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">1</cn>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_f_L</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="per_second">67.922</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <ci>E0_f_L</ci>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">4</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>f_L_infinity</ci>
+            <apply>
+               <divide/>
+               <ci>alpha_f_L</ci>
+               <apply>
+                  <plus/>
+                  <ci>alpha_f_L</ci>
+                  <ci>beta_f_L</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_f_L</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <ci>alpha_f_L</ci>
+                  <ci>beta_f_L</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>f_L</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>f_L_infinity</ci>
+                  <ci>f_L</ci>
+               </apply>
+               <ci>tau_f_L</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="T_type_Ca_channel">
+      <variable name="i_Ca_T" units="picoA" public_interface="out"/>
+      <variable name="g_Ca_T" units="nanoS" initial_value="0.006"/>
+      <variable name="E_Ca_T" units="millivolt" initial_value="38"/>
+      <variable name="time" units="second" public_interface="in" private_interface="out"/>
+      <variable name="V" units="millivolt" public_interface="in" private_interface="out"/>
+      <variable name="d_T" units="dimensionless" private_interface="in"/>
+      <variable name="f_T" units="dimensionless" private_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_Ca_T</ci>
+            <apply>
+               <times/>
+               <ci>g_Ca_T</ci>
+               <ci>d_T</ci>
+               <ci>f_T</ci>
+               <apply>
+                  <minus/>
+                  <ci>V</ci>
+                  <ci>E_Ca_T</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="T_type_Ca_channel_d_T_gate">
+      <variable name="d_T" units="dimensionless" initial_value="0.00046" public_interface="out"/>
+      <variable name="E0_d_T" units="millivolt"/>
+      <variable name="alpha_d_T" units="per_second"/>
+      <variable name="beta_d_T" units="per_second"/>
+      <variable name="d_T_infinity" units="dimensionless"/>
+      <variable name="tau_d_T" units="second"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E0_d_T</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">23.3</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>alpha_d_T</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">674.173</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>E0_d_T</ci>
+                     <cn cellml:units="millivolt">30</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_d_T</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">674.173</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>E0_d_T</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">30</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>d_T_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <ci>E0_d_T</ci>
+                           <cn cellml:units="millivolt">0.3</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">6.1</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_d_T</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <ci>alpha_d_T</ci>
+                  <ci>beta_d_T</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>d_T</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>d_T_infinity</ci>
+                  <ci>d_T</ci>
+               </apply>
+               <ci>tau_d_T</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="T_type_Ca_channel_f_T_gate">
+      <variable name="f_T" units="dimensionless" initial_value="0.30752" public_interface="out"/>
+      <variable name="E0_f_T" units="millivolt"/>
+      <variable name="alpha_f_T" units="per_second"/>
+      <variable name="beta_f_T" units="per_second"/>
+      <variable name="f_T_infinity" units="dimensionless" public_interface="out"/>
+      <variable name="tau_f_T" units="second"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E0_f_T</ci>
+            <apply>
+               <plus/>
+               <ci>V</ci>
+               <cn cellml:units="millivolt">75</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>alpha_f_T</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">9.637</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>E0_f_T</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">83.3</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_f_T</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">9.637</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>E0_f_T</ci>
+                     <cn cellml:units="millivolt">15.38</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>f_T_infinity</ci>
+            <apply>
+               <divide/>
+               <ci>alpha_f_T</ci>
+               <apply>
+                  <plus/>
+                  <ci>alpha_f_T</ci>
+                  <ci>beta_f_T</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_f_T</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <ci>alpha_f_T</ci>
+                  <ci>beta_f_T</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>f_T</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>f_T_infinity</ci>
+                  <ci>f_T</ci>
+               </apply>
+               <ci>tau_f_T</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="Ca_independent_transient_outward_K_current">
+      <variable name="i_to" units="picoA" public_interface="out"/>
+      <variable name="i_sus" units="picoA" public_interface="out"/>
+      <variable name="E_K" units="millivolt" public_interface="out"/>
+      <variable name="g_to" units="nanoS" initial_value="0.050002"/>
+      <variable name="time" units="second" public_interface="in" private_interface="out"/>
+      <variable name="V" units="millivolt" public_interface="in" private_interface="out"/>
+      <variable name="R" units="millijoule_per_mole_kelvin" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="T" units="kelvin" public_interface="in"/>
+      <variable name="K_c" units="millimolar" public_interface="in"/>
+      <variable name="K_i" units="millimolar" public_interface="in"/>
+      <variable name="r" units="dimensionless" private_interface="in"/>
+      <variable name="s1" units="dimensionless" private_interface="in"/>
+      <variable name="s2" units="dimensionless" private_interface="in"/>
+      <variable name="s3" units="dimensionless" private_interface="in"/>
+      <variable name="CT" units="dimensionless" public_interface="in"/>
+      <variable name="PM" units="dimensionless" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E_K</ci>
+            <apply>
+               <times/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <times/>
+                     <ci>R</ci>
+                     <ci>T</ci>
+                  </apply>
+                  <ci>F</ci>
+               </apply>
+               <apply>
+                  <ln/>
+                  <apply>
+                     <divide/>
+                     <ci>K_c</ci>
+                     <ci>K_i</ci>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_to</ci>
+            <piecewise>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">0.2</cn>
+                     <ci>g_to</ci>
+                     <ci>r</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.59</cn>
+                           <apply>
+                              <power/>
+                              <ci>s1</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                        </apply>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.41</cn>
+                           <apply>
+                              <power/>
+                              <ci>s2</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.6</cn>
+                           <apply>
+                              <power/>
+                              <ci>s3</ci>
+                              <cn cellml:units="dimensionless">6</cn>
+                           </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">0.4</cn>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_K</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">0.35</cn>
+                     <ci>g_to</ci>
+                     <ci>r</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.59</cn>
+                           <apply>
+                              <power/>
+                              <ci>s1</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                        </apply>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.41</cn>
+                           <apply>
+                              <power/>
+                              <ci>s2</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.6</cn>
+                           <apply>
+                              <power/>
+                              <ci>s3</ci>
+                              <cn cellml:units="dimensionless">6</cn>
+                           </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">0.4</cn>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_K</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <apply>
+                     <times/>
+                     <ci>g_to</ci>
+                     <ci>r</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.59</cn>
+                           <apply>
+                              <power/>
+                              <ci>s1</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                        </apply>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.41</cn>
+                           <apply>
+                              <power/>
+                              <ci>s2</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <cn cellml:units="dimensionless">0.6</cn>
+                           <apply>
+                              <power/>
+                              <ci>s3</ci>
+                              <cn cellml:units="dimensionless">6</cn>
+                           </apply>
+                        </apply>
+                        <cn cellml:units="dimensionless">0.4</cn>
+                     </apply>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_K</ci>
+                     </apply>
+                  </apply>
+               </otherwise>
+            </piecewise>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_sus</ci>
+            <piecewise>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.0014</cn>
+                     <apply>
+                        <plus/>
+                        <ci>V</ci>
+                        <cn cellml:units="millivolt">70</cn>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.0024</cn>
+                     <apply>
+                        <plus/>
+                        <ci>V</ci>
+                        <cn cellml:units="millivolt">70</cn>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.001</cn>
+                     <apply>
+                        <plus/>
+                        <ci>V</ci>
+                        <cn cellml:units="millivolt">70</cn>
+                     </apply>
+                  </apply>
+               </otherwise>
+            </piecewise>
+         </apply>
+      </math>
+   </component>
+   <component name="Ca_independent_transient_outward_K_current_r_gate">
+      <variable name="r" units="dimensionless" initial_value="0.00006" public_interface="out"/>
+      <variable name="alpha_r" units="per_second"/>
+      <variable name="beta_r" units="per_second"/>
+      <variable name="tau_r" units="second"/>
+      <variable name="r_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_r</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">386.6</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <cn cellml:units="millivolt">12</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_r</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">8.011</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">7.2</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>r_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">15</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">5.633</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_r</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <plus/>
+                     <ci>alpha_r</ci>
+                     <ci>beta_r</ci>
+                  </apply>
+               </apply>
+               <cn type="e-notation" cellml:units="second">4   <sep/>
+               -4</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>r</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>r_infinity</ci>
+                  <ci>r</ci>
+               </apply>
+               <ci>tau_r</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="Ca_independent_transient_outward_K_current_s1_gate">
+      <variable name="s1" units="dimensionless" initial_value="0.5753" public_interface="out"/>
+      <variable name="tau_s1" units="second"/>
+      <variable name="s1_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>s1_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">28.29</cn>
+                        </apply>
+                        <cn cellml:units="millivolt">7.06</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_s1</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="second">0.5466</cn>
+                  <apply>
+                     <plus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <plus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">32.8</cn>
+                           </apply>
+                           <cn cellml:units="millivolt">0.1</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <cn cellml:units="second">0.0204</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>s1</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>s1_infinity</ci>
+                  <ci>s1</ci>
+               </apply>
+               <ci>tau_s1</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="Ca_independent_transient_outward_K_current_s2_gate">
+      <variable name="s2" units="dimensionless" initial_value="0.39871" public_interface="out"/>
+      <variable name="tau_s2" units="second"/>
+      <variable name="s2_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>s2_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">28.29</cn>
+                        </apply>
+                        <cn cellml:units="millivolt">7.06</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_s2</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="second">5.75</cn>
+                  <apply>
+                     <plus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <plus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">32.8</cn>
+                           </apply>
+                           <cn cellml:units="millivolt">0.1</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="second">0.45</cn>
+                  <apply>
+                     <plus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <minus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">13.54</cn>
+                           </apply>
+                           <apply>
+                              <minus/>
+                              <cn cellml:units="millivolt">13.97</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>s2</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>s2_infinity</ci>
+                  <ci>s2</ci>
+               </apply>
+               <ci>tau_s2</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="Ca_independent_transient_outward_K_current_s3_gate">
+      <variable name="s3" units="dimensionless" initial_value="0.57363" public_interface="out"/>
+      <variable name="tau_s3" units="second"/>
+      <variable name="s3_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>s3_infinity</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <plus/>
+                  <apply>
+                     <divide/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                           <exp/>
+                           <apply>
+                              <divide/>
+                              <apply>
+                                 <plus/>
+                                 <ci>V</ci>
+                                 <cn cellml:units="millivolt">50.67</cn>
+                              </apply>
+                              <cn cellml:units="millivolt">27.38</cn>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">0.666</cn>
+               </apply>
+               <cn cellml:units="dimensionless">1.666</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_s3</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="second">7.5</cn>
+                  <apply>
+                     <plus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <apply>
+                        <exp/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <plus/>
+                              <ci>V</ci>
+                              <cn cellml:units="millivolt">23</cn>
+                           </apply>
+                           <cn cellml:units="millivolt">0.5</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <cn cellml:units="second">0.5</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>s3</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>s3_infinity</ci>
+                  <ci>s3</ci>
+               </apply>
+               <ci>tau_s3</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="delayed_rectifier_K_current">
+      <variable name="i_Ks" units="picoA" public_interface="out"/>
+      <variable name="i_Kr" units="picoA" public_interface="out"/>
+      <variable name="g_Ks" units="nanoS" initial_value="0.0025"/>
+      <variable name="g_Kr" units="nanoS" initial_value="0.0035"/>
+      <variable name="time" units="second" public_interface="in" private_interface="out"/>
+      <variable name="V" units="millivolt" public_interface="in" private_interface="out"/>
+      <variable name="E_K" units="millivolt" public_interface="in"/>
+      <variable name="z" units="dimensionless" private_interface="in"/>
+      <variable name="p_a" units="dimensionless" private_interface="in"/>
+      <variable name="p_i" units="dimensionless" private_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_Ks</ci>
+            <apply>
+               <times/>
+               <ci>g_Ks</ci>
+               <ci>z</ci>
+               <apply>
+                  <minus/>
+                  <ci>V</ci>
+                  <ci>E_K</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_Kr</ci>
+            <apply>
+               <times/>
+               <ci>g_Kr</ci>
+               <ci>p_a</ci>
+               <ci>p_i</ci>
+               <apply>
+                  <minus/>
+                  <ci>V</ci>
+                  <ci>E_K</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="delayed_rectifier_K_current_z_gate">
+      <variable name="z" units="dimensionless" initial_value="0.02032" public_interface="out"/>
+      <variable name="alpha_z" units="per_second"/>
+      <variable name="beta_z" units="per_second"/>
+      <variable name="tau_z" units="second"/>
+      <variable name="z_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_z</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">1.66</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <cn cellml:units="millivolt">69.452</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_z</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">0.3</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">21.826</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>z_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">0.9</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">13.8</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_z</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <divide/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <plus/>
+                     <ci>alpha_z</ci>
+                     <ci>beta_z</ci>
+                  </apply>
+               </apply>
+               <cn cellml:units="second">0.06</cn>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>z</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>z_infinity</ci>
+                  <ci>z</ci>
+               </apply>
+               <ci>tau_z</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="delayed_rectifier_K_current_pa_gate">
+      <variable name="p_a" units="dimensionless" initial_value="0.00016" public_interface="out"/>
+      <variable name="alpha_p_a" units="per_second"/>
+      <variable name="beta_p_a" units="per_second"/>
+      <variable name="tau_p_a" units="second"/>
+      <variable name="p_a_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_p_a</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">9</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <cn cellml:units="millivolt">25.371</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_p_a</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">1.3</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">13.026</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>p_a_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">5.1</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">7.4</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_p_a</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <ci>alpha_p_a</ci>
+                  <ci>beta_p_a</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>p_a</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>p_a_infinity</ci>
+                  <ci>p_a</ci>
+               </apply>
+               <ci>tau_p_a</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="delayed_rectifier_K_current_pi_gate">
+      <variable name="p_i" units="dimensionless" initial_value="0.76898" public_interface="out"/>
+      <variable name="alpha_p_i" units="per_second"/>
+      <variable name="beta_p_i" units="per_second"/>
+      <variable name="tau_p_i" units="second"/>
+      <variable name="p_i_infinity" units="dimensionless"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>alpha_p_i</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">100</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="millivolt">54.645</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>beta_p_i</ci>
+            <apply>
+               <times/>
+               <cn cellml:units="per_second">656</cn>
+               <apply>
+                  <exp/>
+                  <apply>
+                     <divide/>
+                     <ci>V</ci>
+                     <cn cellml:units="millivolt">106.157</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>p_i_infinity</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">47.3921</cn>
+                        </apply>
+                        <cn cellml:units="millivolt">18.6603</cn>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>tau_p_i</ci>
+            <apply>
+               <divide/>
+               <cn cellml:units="dimensionless">1</cn>
+               <apply>
+                  <plus/>
+                  <ci>alpha_p_i</ci>
+                  <ci>beta_p_i</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>p_i</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>p_i_infinity</ci>
+                  <ci>p_i</ci>
+               </apply>
+               <ci>tau_p_i</ci>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="inward_rectifier">
+      <variable name="i_K1" units="picoA" public_interface="out"/>
+      <variable name="g_K1" units="nanoS" initial_value="0.00508"/>
+      <variable name="KmK1" units="millimolar" initial_value="0.59"/>
+      <variable name="steepK1" units="dimensionless" initial_value="1.393"/>
+      <variable name="shiftK1" units="millivolt" initial_value="-3.6"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="R" units="millijoule_per_mole_kelvin" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="T" units="kelvin" public_interface="in"/>
+      <variable name="K_c" units="millimolar" public_interface="in"/>
+      <variable name="E_K" units="millivolt" public_interface="in"/>
+      <variable name="CT" units="dimensionless" public_interface="in"/>
+      <variable name="PM" units="dimensionless" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_K1</ci>
+            <piecewise>
+               <piece>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">2</cn>
+                        <ci>g_K1</ci>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                           <ci>E_K</ci>
+                        </apply>
+                        <apply>
+                           <power/>
+                           <apply>
+                              <divide/>
+                              <ci>K_c</ci>
+                              <apply>
+                                 <plus/>
+                                 <ci>K_c</ci>
+                                 <ci>KmK1</ci>
+                              </apply>
+                           </apply>
+                           <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                           <exp/>
+                           <apply>
+                              <divide/>
+                              <apply>
+                                 <times/>
+                                 <ci>steepK1</ci>
+                                 <ci>F</ci>
+                                 <apply>
+                                    <minus/>
+                                    <apply>
+                                       <minus/>
+                                       <ci>V</ci>
+                                       <ci>E_K</ci>
+                                    </apply>
+                                    <ci>shiftK1</ci>
+                                 </apply>
+                              </apply>
+                              <apply>
+                                 <times/>
+                                 <ci>R</ci>
+                                 <ci>T</ci>
+                              </apply>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <piece>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">2.5</cn>
+                        <ci>g_K1</ci>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                           <ci>E_K</ci>
+                        </apply>
+                        <apply>
+                           <power/>
+                           <apply>
+                              <divide/>
+                              <ci>K_c</ci>
+                              <apply>
+                                 <plus/>
+                                 <ci>K_c</ci>
+                                 <ci>KmK1</ci>
+                              </apply>
+                           </apply>
+                           <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                           <exp/>
+                           <apply>
+                              <divide/>
+                              <apply>
+                                 <times/>
+                                 <ci>steepK1</ci>
+                                 <ci>F</ci>
+                                 <apply>
+                                    <minus/>
+                                    <apply>
+                                       <minus/>
+                                       <ci>V</ci>
+                                       <ci>E_K</ci>
+                                    </apply>
+                                    <ci>shiftK1</ci>
+                                 </apply>
+                              </apply>
+                              <apply>
+                                 <times/>
+                                 <ci>R</ci>
+                                 <ci>T</ci>
+                              </apply>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <times/>
+                        <ci>g_K1</ci>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                           <ci>E_K</ci>
+                        </apply>
+                        <apply>
+                           <power/>
+                           <apply>
+                              <divide/>
+                              <ci>K_c</ci>
+                              <apply>
+                                 <plus/>
+                                 <ci>K_c</ci>
+                                 <ci>KmK1</ci>
+                              </apply>
+                           </apply>
+                           <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <apply>
+                           <exp/>
+                           <apply>
+                              <divide/>
+                              <apply>
+                                 <times/>
+                                 <ci>steepK1</ci>
+                                 <ci>F</ci>
+                                 <apply>
+                                    <minus/>
+                                    <apply>
+                                       <minus/>
+                                       <ci>V</ci>
+                                       <ci>E_K</ci>
+                                    </apply>
+                                    <ci>shiftK1</ci>
+                                 </apply>
+                              </apply>
+                              <apply>
+                                 <times/>
+                                 <ci>R</ci>
+                                 <ci>T</ci>
+                              </apply>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+               </otherwise>
+            </piecewise>
+         </apply>
+      </math>
+   </component>
+   <component name="background_currents">
+      <variable name="i_B_Na" units="picoA" public_interface="out"/>
+      <variable name="i_B_Ca" units="picoA" public_interface="out"/>
+      <variable name="g_B_Na" units="nanoS" initial_value="6.4e-5"/>
+      <variable name="g_B_Ca" units="nanoS" initial_value="3.1e-5"/>
+      <variable name="E_Ca" units="millivolt"/>
+      <variable name="E_Na" units="millivolt" public_interface="in"/>
+      <variable name="R" units="millijoule_per_mole_kelvin" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="T" units="kelvin" public_interface="in"/>
+      <variable name="Ca_c" units="millimolar" public_interface="in"/>
+      <variable name="Ca_i" units="millimolar" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="CT" units="dimensionless" public_interface="in"/>
+      <variable name="PM" units="dimensionless" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>E_Ca</ci>
+            <apply>
+               <times/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <times/>
+                     <ci>R</ci>
+                     <ci>T</ci>
+                  </apply>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">2</cn>
+                     <ci>F</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <ln/>
+                  <apply>
+                     <divide/>
+                     <ci>Ca_c</ci>
+                     <ci>Ca_i</ci>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_B_Na</ci>
+            <piecewise>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.00002</cn>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Na</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.00003</cn>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Na</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <apply>
+                     <times/>
+                     <ci>g_B_Na</ci>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Na</ci>
+                     </apply>
+                  </apply>
+               </otherwise>
+            </piecewise>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_B_Ca</ci>
+            <piecewise>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.00002</cn>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Ca</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <piece>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="nanoS">0.00003</cn>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Ca</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <and/>
+                     <apply>
+                        <eq/>
+                        <ci>CT</ci>
+                        <cn cellml:units="dimensionless">0</cn>
+                     </apply>
+                     <apply>
+                        <eq/>
+                        <ci>PM</ci>
+                        <cn cellml:units="dimensionless">1</cn>
+                     </apply>
+                  </apply>
+               </piece>
+               <otherwise>
+                  <apply>
+                     <times/>
+                     <ci>g_B_Ca</ci>
+                     <apply>
+                        <minus/>
+                        <ci>V</ci>
+                        <ci>E_Ca</ci>
+                     </apply>
+                  </apply>
+               </otherwise>
+            </piecewise>
+         </apply>
+      </math>
+   </component>
+   <component name="sodium_potassium_pump">
+      <variable name="i_p" units="picoA" public_interface="out"/>
+      <variable name="k_NaK_K" units="millimolar" initial_value="1"/>
+      <variable name="k_NaK_Na" units="millimolar" initial_value="11"/>
+      <variable name="i_NaK_max" units="picoA" initial_value="0.06441"/>
+      <variable name="K_c" units="millimolar" public_interface="in"/>
+      <variable name="Na_i" units="millimolar" public_interface="in"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_p</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <times/>
+                        <apply>
+                           <divide/>
+                           <apply>
+                              <times/>
+                              <ci>i_NaK_max</ci>
+                              <ci>K_c</ci>
+                           </apply>
+                           <apply>
+                              <plus/>
+                              <ci>K_c</ci>
+                              <ci>k_NaK_K</ci>
+                           </apply>
+                        </apply>
+                        <apply>
+                           <power/>
+                           <ci>Na_i</ci>
+                           <cn cellml:units="dimensionless">1.5</cn>
+                        </apply>
+                     </apply>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <power/>
+                           <ci>Na_i</ci>
+                           <cn cellml:units="dimensionless">1.5</cn>
+                        </apply>
+                        <apply>
+                           <power/>
+                           <ci>k_NaK_Na</ci>
+                           <cn cellml:units="dimensionless">1.5</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">1.6</cn>
+               </apply>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1.5</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <plus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">60</cn>
+                        </apply>
+                        <apply>
+                           <minus/>
+                           <cn cellml:units="millivolt">40</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="sarcolemmal_calcium_pump_current">
+      <variable name="i_CaP" units="picoA" public_interface="out"/>
+      <variable name="i_CaP_max" units="picoA" initial_value="0.009509"/>
+      <variable name="k_CaP" units="millimolar" initial_value="2e-4"/>
+      <variable name="Ca_i" units="millimolar" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_CaP</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <ci>i_CaP_max</ci>
+                  <ci>Ca_i</ci>
+               </apply>
+               <apply>
+                  <plus/>
+                  <ci>Ca_i</ci>
+                  <ci>k_CaP</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="Na_Ca_ion_exchanger_current">
+      <variable name="i_NaCa" units="picoA" public_interface="out"/>
+      <variable name="k_NaCa" units="picoA_per_millimolar_4" initial_value="2e-5"/>
+      <variable name="d_NaCa" units="per_millimolar_4" initial_value="3e-4"/>
+      <variable name="gamma" units="dimensionless" initial_value="0.45"/>
+      <variable name="Na_i" units="millimolar" public_interface="in"/>
+      <variable name="Na_c" units="millimolar" public_interface="in"/>
+      <variable name="Ca_i" units="millimolar" public_interface="in"/>
+      <variable name="Ca_c" units="millimolar" public_interface="in"/>
+      <variable name="R" units="millijoule_per_mole_kelvin" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="T" units="kelvin" public_interface="in"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>i_NaCa</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <ci>k_NaCa</ci>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <times/>
+                        <apply>
+                           <power/>
+                           <ci>Na_i</ci>
+                           <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                        <ci>Ca_c</ci>
+                        <apply>
+                           <exp/>
+                           <apply>
+                              <divide/>
+                              <apply>
+                                 <times/>
+                                 <ci>gamma</ci>
+                                 <ci>F</ci>
+                                 <ci>V</ci>
+                              </apply>
+                              <apply>
+                                 <times/>
+                                 <ci>R</ci>
+                                 <ci>T</ci>
+                              </apply>
+                           </apply>
+                        </apply>
+                     </apply>
+                     <apply>
+                        <times/>
+                        <apply>
+                           <power/>
+                           <ci>Na_c</ci>
+                           <cn cellml:units="dimensionless">3</cn>
+                        </apply>
+                        <ci>Ca_i</ci>
+                        <apply>
+                           <exp/>
+                           <apply>
+                              <divide/>
+                              <apply>
+                                 <times/>
+                                 <apply>
+                                    <minus/>
+                                    <ci>gamma</ci>
+                                    <cn cellml:units="dimensionless">1</cn>
+                                 </apply>
+                                 <ci>V</ci>
+                                 <ci>F</ci>
+                              </apply>
+                              <apply>
+                                 <times/>
+                                 <ci>R</ci>
+                                 <ci>T</ci>
+                              </apply>
+                           </apply>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <plus/>
+                  <cn cellml:units="dimensionless">1</cn>
+                  <apply>
+                     <times/>
+                     <ci>d_NaCa</ci>
+                     <apply>
+                        <plus/>
+                        <apply>
+                           <times/>
+                           <apply>
+                              <power/>
+                              <ci>Na_c</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                           <ci>Ca_i</ci>
+                        </apply>
+                        <apply>
+                           <times/>
+                           <apply>
+                              <power/>
+                              <ci>Na_i</ci>
+                              <cn cellml:units="dimensionless">3</cn>
+                           </apply>
+                           <ci>Ca_c</ci>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="intracellular_ion_concentrations">
+      <variable name="Na_i" units="millimolar" initial_value="8.4" public_interface="out"/>
+      <variable name="Ca_i" units="millimolar" initial_value="0.000071" public_interface="out"/>
+      <variable name="K_i" units="millimolar" initial_value="100" public_interface="out"/>
+      <variable name="Vol_i" units="nanolitre" initial_value="1.26e-5" public_interface="out"/>
+      <variable name="Vol_Ca" units="nanolitre" initial_value="5.884e-6"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="i_Na" units="picoA" public_interface="in"/>
+      <variable name="i_Ca_L" units="picoA" public_interface="in"/>
+      <variable name="i_Ca_T" units="picoA" public_interface="in"/>
+      <variable name="i_B_Na" units="picoA" public_interface="in"/>
+      <variable name="i_NaCa" units="picoA" public_interface="in"/>
+      <variable name="i_p" units="picoA" public_interface="in"/>
+      <variable name="i_Kr" units="picoA" public_interface="in"/>
+      <variable name="i_Ks" units="picoA" public_interface="in"/>
+      <variable name="i_K1" units="picoA" public_interface="in"/>
+      <variable name="i_to" units="picoA" public_interface="in"/>
+      <variable name="i_sus" units="picoA" public_interface="in"/>
+      <variable name="i_CaP" units="picoA" public_interface="in"/>
+      <variable name="i_B_Ca" units="picoA" public_interface="in"/>
+      <variable name="i_up" units="picoA" public_interface="in"/>
+      <variable name="i_rel" units="picoA" public_interface="in"/>
+      <variable name="dOCdt" units="per_second" public_interface="in"/>
+      <variable name="dOTCdt" units="per_second" public_interface="in"/>
+      <variable name="dOTMgCdt" units="per_second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>Na_i</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <plus/>
+                     <ci>i_Na</ci>
+                     <ci>i_B_Na</ci>
+                     <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">3</cn>
+                        <ci>i_p</ci>
+                     </apply>
+                     <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">3</cn>
+                        <ci>i_NaCa</ci>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>Vol_i</ci>
+                  <ci>F</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>K_i</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <plus/>
+                        <ci>i_to</ci>
+                        <ci>i_sus</ci>
+                        <ci>i_K1</ci>
+                        <ci>i_Kr</ci>
+                        <ci>i_Ks</ci>
+                     </apply>
+                     <apply>
+                        <times/>
+                        <cn cellml:units="dimensionless">2</cn>
+                        <ci>i_p</ci>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>Vol_i</ci>
+                  <ci>F</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>Ca_i</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <minus/>
+                        <apply>
+                           <plus/>
+                           <apply>
+                              <minus/>
+                              <apply>
+                                 <plus/>
+                                 <ci>i_Ca_L</ci>
+                                 <ci>i_Ca_T</ci>
+                                 <ci>i_B_Ca</ci>
+                                 <ci>i_CaP</ci>
+                              </apply>
+                              <apply>
+                                 <times/>
+                                 <cn cellml:units="dimensionless">2</cn>
+                                 <ci>i_NaCa</ci>
+                              </apply>
+                           </apply>
+                           <ci>i_up</ci>
+                        </apply>
+                        <ci>i_rel</ci>
+                     </apply>
+                  </apply>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">2</cn>
+                     <ci>Vol_Ca</ci>
+                     <ci>F</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <plus/>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="millimolar">0.08</cn>
+                     <ci>dOTCdt</ci>
+                  </apply>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="millimolar">0.16</cn>
+                     <ci>dOTMgCdt</ci>
+                  </apply>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="millimolar">0.045</cn>
+                     <ci>dOCdt</ci>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="intracellular_Ca_buffering">
+      <variable name="O_C" units="dimensionless" initial_value="0.029108"/>
+      <variable name="dOCdt" units="per_second" public_interface="out"/>
+      <variable name="O_TC" units="dimensionless" initial_value="0.014071"/>
+      <variable name="dOTCdt" units="per_second" public_interface="out"/>
+      <variable name="O_TMgC" units="dimensionless" initial_value="0.214036"/>
+      <variable name="dOTMgCdt" units="per_second" public_interface="out"/>
+      <variable name="O_TMgMg" units="dimensionless" initial_value="0.693565" public_interface="out"/>
+      <variable name="Mg_i" units="millimolar" initial_value="2.5"/>
+      <variable name="Ca_i" units="millimolar" public_interface="in"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <ci>dOCdt</ci>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millimolar_second">200000</cn>
+                  <ci>Ca_i</ci>
+                  <apply>
+                     <minus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <ci>O_C</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">476</cn>
+                  <ci>O_C</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>O_C</ci>
+            </apply>
+            <ci>dOCdt</ci>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>dOTCdt</ci>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millimolar_second">78400</cn>
+                  <ci>Ca_i</ci>
+                  <apply>
+                     <minus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <ci>O_TC</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">392</cn>
+                  <ci>O_TC</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>O_TC</ci>
+            </apply>
+            <ci>dOTCdt</ci>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>dOTMgCdt</ci>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millimolar_second">200000</cn>
+                  <ci>Ca_i</ci>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>O_TMgC</ci>
+                     </apply>
+                     <ci>O_TMgMg</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">6.6</cn>
+                  <ci>O_TMgC</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>O_TMgC</ci>
+            </apply>
+            <ci>dOTMgCdt</ci>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>O_TMgMg</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millimolar_second">2000</cn>
+                  <ci>Mg_i</ci>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <minus/>
+                        <cn cellml:units="dimensionless">1</cn>
+                        <ci>O_TMgC</ci>
+                     </apply>
+                     <ci>O_TMgMg</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">666</cn>
+                  <ci>O_TMgMg</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="cleft_space_ion_concentrations">
+      <variable name="Na_c" units="millimolar" initial_value="140" public_interface="out"/>
+      <variable name="Ca_c" units="millimolar" initial_value="2.5" public_interface="out"/>
+      <variable name="K_c" units="millimolar" initial_value="5" public_interface="out"/>
+      <variable name="Vol_c" units="nanolitre" initial_value="0.0000025" public_interface="out"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <variable name="i_p" units="picoA" public_interface="in"/>
+      <variable name="i_Kr" units="picoA" public_interface="in"/>
+      <variable name="i_Ks" units="picoA" public_interface="in"/>
+      <variable name="i_K1" units="picoA" public_interface="in"/>
+      <variable name="i_to" units="picoA" public_interface="in"/>
+      <variable name="i_sus" units="picoA" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>K_c</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <apply>
+                     <plus/>
+                     <ci>i_to</ci>
+                     <ci>i_sus</ci>
+                     <ci>i_K1</ci>
+                     <ci>i_Kr</ci>
+                     <ci>i_Ks</ci>
+                  </apply>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">2</cn>
+                     <ci>i_p</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>Vol_c</ci>
+                  <ci>F</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <component name="Ca_handling_by_the_SR">
+      <variable name="i_rel" units="picoA" public_interface="out"/>
+      <variable name="i_up" units="picoA" public_interface="out"/>
+      <variable name="i_tr" units="picoA"/>
+      <variable name="I_up_max" units="picoA" initial_value="2.8"/>
+      <variable name="k_cyca" units="millimolar" initial_value="0.0003"/>
+      <variable name="k_srca" units="millimolar" initial_value="0.5"/>
+      <variable name="k_xcs" units="dimensionless" initial_value="0.4"/>
+      <variable name="alpha_rel" units="picoA_per_millimolar" initial_value="200"/>
+      <variable name="Ca_rel" units="millimolar" initial_value="0.726776"/>
+      <variable name="Ca_up" units="millimolar" initial_value="0.730866"/>
+      <variable name="Vol_up" units="nanolitre" initial_value="3.969e-7"/>
+      <variable name="Vol_rel" units="nanolitre" initial_value="4.4e-8"/>
+      <variable name="r_act" units="per_second"/>
+      <variable name="r_inact" units="per_second"/>
+      <variable name="O_Calse" units="dimensionless" initial_value="0.465921"/>
+      <variable name="F1" units="dimensionless" initial_value="0.288039"/>
+      <variable name="F2" units="dimensionless" initial_value="0.002262"/>
+      <variable name="F3" units="dimensionless" initial_value="0.612697"/>
+      <variable name="tau_tr" units="second" initial_value="0.01"/>
+      <variable name="k_rel" units="millimolar" initial_value="0.0003"/>
+      <variable name="k_F3" units="per_second" initial_value="0.815"/>
+      <variable name="time" units="second" public_interface="in"/>
+      <variable name="Ca_i" units="millimolar" public_interface="in"/>
+      <variable name="V" units="millivolt" public_interface="in"/>
+      <variable name="F" units="coulomb_per_mole" public_interface="in"/>
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>O_Calse</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_millimolar_second">480</cn>
+                  <ci>Ca_rel</ci>
+                  <apply>
+                     <minus/>
+                     <cn cellml:units="dimensionless">1</cn>
+                     <ci>O_Calse</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">400</cn>
+                  <ci>O_Calse</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>Ca_rel</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <divide/>
+                  <apply>
+                     <minus/>
+                     <ci>i_tr</ci>
+                     <ci>i_rel</ci>
+                  </apply>
+                  <apply>
+                     <times/>
+                     <cn cellml:units="dimensionless">2</cn>
+                     <ci>Vol_rel</ci>
+                     <ci>F</ci>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="millimolar">31</cn>
+                  <apply>
+                     <diff/>
+                     <bvar>
+                        <ci>time</ci>
+                     </bvar>
+                     <ci>O_Calse</ci>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>Ca_up</ci>
+            </apply>
+            <apply>
+               <divide/>
+               <apply>
+                  <minus/>
+                  <ci>i_up</ci>
+                  <ci>i_tr</ci>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="dimensionless">2</cn>
+                  <ci>Vol_up</ci>
+                  <ci>F</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>F1</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>k_F3</ci>
+                  <ci>F3</ci>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>r_act</ci>
+                  <ci>F1</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>F2</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>r_act</ci>
+                  <ci>F1</ci>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>r_inact</ci>
+                  <ci>F2</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <apply>
+               <diff/>
+               <bvar>
+                  <ci>time</ci>
+               </bvar>
+               <ci>F3</ci>
+            </apply>
+            <apply>
+               <minus/>
+               <apply>
+                  <times/>
+                  <ci>F2</ci>
+                  <ci>r_inact</ci>
+               </apply>
+               <apply>
+                  <times/>
+                  <ci>k_F3</ci>
+                  <ci>F3</ci>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>r_act</ci>
+            <apply>
+               <plus/>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">240</cn>
+                  <apply>
+                     <exp/>
+                     <apply>
+                        <times/>
+                        <cn cellml:units="per_millivolt">0.08</cn>
+                        <apply>
+                           <minus/>
+                           <ci>V</ci>
+                           <cn cellml:units="millivolt">20</cn>
+                        </apply>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">203.8</cn>
+                  <apply>
+                     <power/>
+                     <apply>
+                        <divide/>
+                        <ci>Ca_i</ci>
+                        <apply>
+                           <plus/>
+                           <ci>Ca_i</ci>
+                           <ci>k_rel</ci>
+                        </apply>
+                     </apply>
+                     <cn cellml:units="dimensionless">4</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>r_inact</ci>
+            <apply>
+               <plus/>
+               <cn cellml:units="per_second">33.96</cn>
+               <apply>
+                  <times/>
+                  <cn cellml:units="per_second">339.6</cn>
+                  <apply>
+                     <power/>
+                     <apply>
+                        <divide/>
+                        <ci>Ca_i</ci>
+                        <apply>
+                           <plus/>
+                           <ci>Ca_i</ci>
+                           <ci>k_rel</ci>
+                        </apply>
+                     </apply>
+                     <cn cellml:units="dimensionless">4</cn>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_up</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <ci>I_up_max</ci>
+                  <apply>
+                     <minus/>
+                     <apply>
+                        <divide/>
+                        <ci>Ca_i</ci>
+                        <ci>k_cyca</ci>
+                     </apply>
+                     <apply>
+                        <divide/>
+                        <apply>
+                           <times/>
+                           <apply>
+                              <power/>
+                              <ci>k_xcs</ci>
+                              <cn cellml:units="dimensionless">2</cn>
+                           </apply>
+                           <ci>Ca_up</ci>
+                        </apply>
+                        <ci>k_srca</ci>
+                     </apply>
+                  </apply>
+               </apply>
+               <apply>
+                  <plus/>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <plus/>
+                        <ci>Ca_i</ci>
+                        <ci>k_cyca</ci>
+                     </apply>
+                     <ci>k_cyca</ci>
+                  </apply>
+                  <apply>
+                     <divide/>
+                     <apply>
+                        <times/>
+                        <ci>k_xcs</ci>
+                        <apply>
+                           <plus/>
+                           <ci>Ca_up</ci>
+                           <ci>k_srca</ci>
+                        </apply>
+                     </apply>
+                     <ci>k_srca</ci>
+                  </apply>
+               </apply>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_tr</ci>
+            <apply>
+               <divide/>
+               <apply>
+                  <times/>
+                  <apply>
+                     <minus/>
+                     <ci>Ca_up</ci>
+                     <ci>Ca_rel</ci>
+                  </apply>
+                  <cn cellml:units="dimensionless">2</cn>
+                  <ci>F</ci>
+                  <ci>Vol_rel</ci>
+               </apply>
+               <ci>tau_tr</ci>
+            </apply>
+         </apply>
+         <apply>
+            <eq/>
+            <ci>i_rel</ci>
+            <apply>
+               <times/>
+               <ci>alpha_rel</ci>
+               <apply>
+                  <power/>
+                  <apply>
+                     <divide/>
+                     <ci>F2</ci>
+                     <apply>
+                        <plus/>
+                        <ci>F2</ci>
+                        <cn cellml:units="dimensionless">0.25</cn>
+                     </apply>
+                  </apply>
+                  <cn cellml:units="dimensionless">2</cn>
+               </apply>
+               <apply>
+                  <minus/>
+                  <ci>Ca_rel</ci>
+                  <ci>Ca_i</ci>
+               </apply>
+            </apply>
+         </apply>
+      </math>
+   </component>
+   <group>
+      <relationship_ref relationship="containment"/>
+      <component_ref component="membrane">
+         <component_ref component="sodium_current">
+            <component_ref component="sodium_current_m_gate"/>
+            <component_ref component="sodium_current_h1_gate"/>
+            <component_ref component="sodium_current_h2_gate"/>
+         </component_ref>
+         <component_ref component="L_type_Ca_channel">
+            <component_ref component="L_type_Ca_channel_d_L_gate"/>
+            <component_ref component="L_type_Ca_channel_f_L_gate"/>
+         </component_ref>
+         <component_ref component="T_type_Ca_channel">
+            <component_ref component="T_type_Ca_channel_d_T_gate"/>
+            <component_ref component="T_type_Ca_channel_f_T_gate"/>
+         </component_ref>
+         <component_ref component="Ca_independent_transient_outward_K_current">
+            <component_ref component="Ca_independent_transient_outward_K_current_r_gate"/>
+            <component_ref component="Ca_independent_transient_outward_K_current_s1_gate"/>
+            <component_ref component="Ca_independent_transient_outward_K_current_s2_gate"/>
+            <component_ref component="Ca_independent_transient_outward_K_current_s3_gate"/>
+         </component_ref>
+         <component_ref component="delayed_rectifier_K_current">
+            <component_ref component="delayed_rectifier_K_current_z_gate"/>
+            <component_ref component="delayed_rectifier_K_current_pa_gate"/>
+            <component_ref component="delayed_rectifier_K_current_pi_gate"/>
+         </component_ref>
+         <component_ref component="inward_rectifier"/>
+         <component_ref component="background_currents"/>
+         <component_ref component="sodium_potassium_pump"/>
+         <component_ref component="sarcolemmal_calcium_pump_current"/>
+         <component_ref component="Na_Ca_ion_exchanger_current"/>
+         <component_ref component="Ca_handling_by_the_SR"/>
+         <component_ref component="intracellular_ion_concentrations"/>
+         <component_ref component="intracellular_Ca_buffering"/>
+         <component_ref component="cleft_space_ion_concentrations"/>
+      </component_ref>
+   </group>
+   <group>
+      <relationship_ref relationship="encapsulation"/>
+      <component_ref component="sodium_current">
+         <component_ref component="sodium_current_m_gate"/>
+         <component_ref component="sodium_current_h1_gate"/>
+         <component_ref component="sodium_current_h2_gate"/>
+      </component_ref>
+      <component_ref component="L_type_Ca_channel">
+         <component_ref component="L_type_Ca_channel_d_L_gate"/>
+         <component_ref component="L_type_Ca_channel_f_L_gate"/>
+      </component_ref>
+      <component_ref component="T_type_Ca_channel">
+         <component_ref component="T_type_Ca_channel_d_T_gate"/>
+         <component_ref component="T_type_Ca_channel_f_T_gate"/>
+      </component_ref>
+      <component_ref component="Ca_independent_transient_outward_K_current">
+         <component_ref component="Ca_independent_transient_outward_K_current_r_gate"/>
+         <component_ref component="Ca_independent_transient_outward_K_current_s1_gate"/>
+         <component_ref component="Ca_independent_transient_outward_K_current_s2_gate"/>
+         <component_ref component="Ca_independent_transient_outward_K_current_s3_gate"/>
+      </component_ref>
+      <component_ref component="delayed_rectifier_K_current">
+         <component_ref component="delayed_rectifier_K_current_z_gate"/>
+         <component_ref component="delayed_rectifier_K_current_pa_gate"/>
+         <component_ref component="delayed_rectifier_K_current_pi_gate"/>
+      </component_ref>
+   </group>
+   <connection>
+      <map_components component_1="membrane" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="L_type_Ca_channel" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="CT" variable_2="CT"/>
+      <map_variables variable_1="PM" variable_2="PM"/>
+   </connection>
+   <connection>
+      <map_components component_1="T_type_Ca_channel" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="CT" variable_2="CT"/>
+      <map_variables variable_1="PM" variable_2="PM"/>
+   </connection>
+   <connection>
+      <map_components component_1="delayed_rectifier_K_current" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="inward_rectifier" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="CT" variable_2="CT"/>
+      <map_variables variable_1="PM" variable_2="PM"/>
+   </connection>
+   <connection>
+      <map_components component_1="background_currents" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="CT" variable_2="CT"/>
+      <map_variables variable_1="PM" variable_2="PM"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_potassium_pump" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="sarcolemmal_calcium_pump_current" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="Na_Ca_ion_exchanger_current" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_handling_by_the_SR" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="intracellular_Ca_buffering" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="intracellular_ion_concentrations" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="cleft_space_ion_concentrations" component_2="environment"/>
+      <map_variables variable_1="time" variable_2="time"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="sodium_current"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="R" variable_2="R"/>
+      <map_variables variable_1="T" variable_2="T"/>
+      <map_variables variable_1="F" variable_2="F"/>
+      <map_variables variable_1="i_Na" variable_2="i_Na"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="L_type_Ca_channel"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_Ca_L" variable_2="i_Ca_L"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="T_type_Ca_channel"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_Ca_T" variable_2="i_Ca_T"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="Ca_independent_transient_outward_K_current"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_to" variable_2="i_to"/>
+      <map_variables variable_1="i_sus" variable_2="i_sus"/>
+      <map_variables variable_1="R" variable_2="R"/>
+      <map_variables variable_1="T" variable_2="T"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="inward_rectifier"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_K1" variable_2="i_K1"/>
+      <map_variables variable_1="R" variable_2="R"/>
+      <map_variables variable_1="T" variable_2="T"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="delayed_rectifier_K_current"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_Kr" variable_2="i_Kr"/>
+      <map_variables variable_1="i_Ks" variable_2="i_Ks"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="background_currents"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_B_Na" variable_2="i_B_Na"/>
+      <map_variables variable_1="i_B_Ca" variable_2="i_B_Ca"/>
+      <map_variables variable_1="R" variable_2="R"/>
+      <map_variables variable_1="T" variable_2="T"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="sodium_potassium_pump"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_p" variable_2="i_p"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="sarcolemmal_calcium_pump_current"/>
+      <map_variables variable_1="i_CaP" variable_2="i_CaP"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="Na_Ca_ion_exchanger_current"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="i_NaCa" variable_2="i_NaCa"/>
+      <map_variables variable_1="R" variable_2="R"/>
+      <map_variables variable_1="T" variable_2="T"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="membrane" component_2="Ca_handling_by_the_SR"/>
+      <map_variables variable_1="V" variable_2="V"/>
+      <map_variables variable_1="F" variable_2="F"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_Na" variable_2="i_Na"/>
+      <map_variables variable_1="Na_i" variable_2="Na_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="background_currents"/>
+      <map_variables variable_1="E_Na" variable_2="E_Na"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="Na_c" variable_2="Na_c"/>
+   </connection>
+   <connection>
+      <map_components component_1="L_type_Ca_channel" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_Ca_L" variable_2="i_Ca_L"/>
+   </connection>
+   <connection>
+      <map_components component_1="T_type_Ca_channel" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_Ca_T" variable_2="i_Ca_T"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_to" variable_2="i_to"/>
+      <map_variables variable_1="i_sus" variable_2="i_sus"/>
+      <map_variables variable_1="K_i" variable_2="K_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="i_to" variable_2="i_to"/>
+      <map_variables variable_1="i_sus" variable_2="i_sus"/>
+      <map_variables variable_1="K_c" variable_2="K_c"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="inward_rectifier"/>
+      <map_variables variable_1="E_K" variable_2="E_K"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="delayed_rectifier_K_current"/>
+      <map_variables variable_1="E_K" variable_2="E_K"/>
+   </connection>
+   <connection>
+      <map_components component_1="delayed_rectifier_K_current" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_Kr" variable_2="i_Kr"/>
+      <map_variables variable_1="i_Ks" variable_2="i_Ks"/>
+   </connection>
+   <connection>
+      <map_components component_1="delayed_rectifier_K_current" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="i_Kr" variable_2="i_Kr"/>
+      <map_variables variable_1="i_Ks" variable_2="i_Ks"/>
+   </connection>
+   <connection>
+      <map_components component_1="inward_rectifier" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_K1" variable_2="i_K1"/>
+   </connection>
+   <connection>
+      <map_components component_1="inward_rectifier" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="i_K1" variable_2="i_K1"/>
+      <map_variables variable_1="K_c" variable_2="K_c"/>
+   </connection>
+   <connection>
+      <map_components component_1="background_currents" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_B_Na" variable_2="i_B_Na"/>
+      <map_variables variable_1="i_B_Ca" variable_2="i_B_Ca"/>
+      <map_variables variable_1="Ca_i" variable_2="Ca_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="background_currents" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="Ca_c" variable_2="Ca_c"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_potassium_pump" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_p" variable_2="i_p"/>
+      <map_variables variable_1="Na_i" variable_2="Na_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_potassium_pump" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="i_p" variable_2="i_p"/>
+      <map_variables variable_1="K_c" variable_2="K_c"/>
+   </connection>
+   <connection>
+      <map_components component_1="sarcolemmal_calcium_pump_current" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_CaP" variable_2="i_CaP"/>
+      <map_variables variable_1="Ca_i" variable_2="Ca_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="Na_Ca_ion_exchanger_current" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="Ca_i" variable_2="Ca_i"/>
+      <map_variables variable_1="Na_i" variable_2="Na_i"/>
+      <map_variables variable_1="i_NaCa" variable_2="i_NaCa"/>
+   </connection>
+   <connection>
+      <map_components component_1="Na_Ca_ion_exchanger_current" component_2="cleft_space_ion_concentrations"/>
+      <map_variables variable_1="Ca_c" variable_2="Ca_c"/>
+      <map_variables variable_1="Na_c" variable_2="Na_c"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_handling_by_the_SR" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="i_rel" variable_2="i_rel"/>
+      <map_variables variable_1="i_up" variable_2="i_up"/>
+      <map_variables variable_1="Ca_i" variable_2="Ca_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="intracellular_Ca_buffering" component_2="intracellular_ion_concentrations"/>
+      <map_variables variable_1="dOCdt" variable_2="dOCdt"/>
+      <map_variables variable_1="dOTCdt" variable_2="dOTCdt"/>
+      <map_variables variable_1="dOTMgCdt" variable_2="dOTMgCdt"/>
+      <map_variables variable_1="Ca_i" variable_2="Ca_i"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="sodium_current_m_gate"/>
+      <map_variables variable_1="m" variable_2="m"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="sodium_current_h1_gate"/>
+      <map_variables variable_1="h1" variable_2="h1"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current" component_2="sodium_current_h2_gate"/>
+      <map_variables variable_1="h2" variable_2="h2"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="sodium_current_h1_gate" component_2="sodium_current_h2_gate"/>
+      <map_variables variable_1="h_infinity" variable_2="h_infinity"/>
+   </connection>
+   <connection>
+      <map_components component_1="L_type_Ca_channel" component_2="L_type_Ca_channel_d_L_gate"/>
+      <map_variables variable_1="d_L" variable_2="d_L"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="L_type_Ca_channel" component_2="L_type_Ca_channel_f_L_gate"/>
+      <map_variables variable_1="f_L" variable_2="f_L"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="T_type_Ca_channel" component_2="T_type_Ca_channel_d_T_gate"/>
+      <map_variables variable_1="d_T" variable_2="d_T"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="T_type_Ca_channel" component_2="T_type_Ca_channel_f_T_gate"/>
+      <map_variables variable_1="f_T" variable_2="f_T"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="Ca_independent_transient_outward_K_current_r_gate"/>
+      <map_variables variable_1="r" variable_2="r"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="Ca_independent_transient_outward_K_current_s1_gate"/>
+      <map_variables variable_1="s1" variable_2="s1"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="Ca_independent_transient_outward_K_current_s2_gate"/>
+      <map_variables variable_1="s2" variable_2="s2"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="Ca_independent_transient_outward_K_current" component_2="Ca_independent_transient_outward_K_current_s3_gate"/>
+      <map_variables variable_1="s3" variable_2="s3"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="delayed_rectifier_K_current" component_2="delayed_rectifier_K_current_z_gate"/>
+      <map_variables variable_1="z" variable_2="z"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="delayed_rectifier_K_current" component_2="delayed_rectifier_K_current_pa_gate"/>
+      <map_variables variable_1="p_a" variable_2="p_a"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+   <connection>
+      <map_components component_1="delayed_rectifier_K_current" component_2="delayed_rectifier_K_current_pi_gate"/>
+      <map_variables variable_1="p_i" variable_2="p_i"/>
+      <map_variables variable_1="time" variable_2="time"/>
+      <map_variables variable_1="V" variable_2="V"/>
+   </connection>
+</model>

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -136,7 +136,9 @@ class TestHodgkin:
         _potassium_channel_n_gate$n
         """
         state_symbols = model.get_state_symbols()
-        assert len(state_symbols) == 4
+        state_symbols_ordered_by_input = model.get_state_symbols(order_by_order_added=True)
+        assert len(state_symbols) == len(state_symbols_ordered_by_input) == 4
+        assert set(state_symbols) == set(state_symbols_ordered_by_input)
 
     def test_free_variable_symbol(self, model):
         """

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -139,6 +139,8 @@ class TestHodgkin:
         state_symbols_ordered_by_input = model.get_state_symbols(order_by_order_added=True)
         assert len(state_symbols) == len(state_symbols_ordered_by_input) == 4
         assert set(state_symbols) == set(state_symbols_ordered_by_input)
+        assert str(state_symbols) == str(state_symbols_ordered_by_input) == \
+            '[_membrane$V, _sodium_channel_m_gate$m, _sodium_channel_h_gate$h, _potassium_channel_n_gate$n]'
 
     def test_free_variable_symbol(self, model):
         """

--- a/tests/test_state_symbols.py
+++ b/tests/test_state_symbols.py
@@ -1,0 +1,58 @@
+import os
+
+import pytest
+
+from cellmlmanip import load_model
+
+OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
+
+
+class TestStateSymbols:
+    @pytest.fixture(scope="class")
+    def model(self):
+        hodgkin_cellml = os.path.join(
+            os.path.dirname(__file__),
+            "cellml_files",
+            "aslanidi_model_2009.cellml"
+        )
+        return load_model(hodgkin_cellml)
+
+    def test_state_symbols(self, model):
+        """
+        _membrane$V
+        _sodium_channel_m_gate$m
+        _sodium_channel_h_gate$h
+        _potassium_channel_n_gate$n
+        """
+        state_symbols = model.get_state_symbols()
+        state_symbols_ordered_by_input = model.get_state_symbols(order_by_order_added=True)
+        assert len(state_symbols) == len(state_symbols_ordered_by_input) == 29
+        assert str(state_symbols) == \
+            '[_membrane$V, _sodium_current_m_gate$m, _sodium_current_h1_gate$h1, _sodium_current_h2_gate$h2, '\
+            '_L_type_Ca_channel_d_L_gate$d_L, _L_type_Ca_channel_f_L_gate$f_L, _T_type_Ca_channel_d_T_gate$d_T, '\
+            '_T_type_Ca_channel_f_T_gate$f_T, _Ca_independent_transient_outward_K_current_r_gate$r, '\
+            '_Ca_independent_transient_outward_K_current_s1_gate$s1, '\
+            '_Ca_independent_transient_outward_K_current_s2_gate$s2, '\
+            '_Ca_independent_transient_outward_K_current_s3_gate$s3, _delayed_rectifier_K_current_z_gate$z, '\
+            '_delayed_rectifier_K_current_pa_gate$p_a, _delayed_rectifier_K_current_pi_gate$p_i, '\
+            '_intracellular_ion_concentrations$Na_i, _intracellular_ion_concentrations$K_i, '\
+            '_intracellular_ion_concentrations$Ca_i, _intracellular_Ca_buffering$O_C, _intracellular_Ca_buffering$O_TC,'\
+            ' _intracellular_Ca_buffering$O_TMgC, _intracellular_Ca_buffering$O_TMgMg, '\
+            '_cleft_space_ion_concentrations$K_c, _Ca_handling_by_the_SR$O_Calse, _Ca_handling_by_the_SR$Ca_rel, '\
+            '_Ca_handling_by_the_SR$Ca_up, _Ca_handling_by_the_SR$F1, _Ca_handling_by_the_SR$F2, '\
+            '_Ca_handling_by_the_SR$F3]'
+        assert str(state_symbols_ordered_by_input) == \
+            '[_membrane$V, _sodium_current_m_gate$m, _sodium_current_h1_gate$h1, _sodium_current_h2_gate$h2, '\
+            '_L_type_Ca_channel_d_L_gate$d_L, _L_type_Ca_channel_f_L_gate$f_L, '\
+            '_T_type_Ca_channel_d_T_gate$d_T, _T_type_Ca_channel_f_T_gate$f_T, '\
+            '_Ca_independent_transient_outward_K_current_r_gate$r, '\
+            '_Ca_independent_transient_outward_K_current_s1_gate$s1, '\
+            '_Ca_independent_transient_outward_K_current_s2_gate$s2, '\
+            '_Ca_independent_transient_outward_K_current_s3_gate$s3, _delayed_rectifier_K_current_z_gate$z, '\
+            '_delayed_rectifier_K_current_pa_gate$p_a, _delayed_rectifier_K_current_pi_gate$p_i, '\
+            '_intracellular_ion_concentrations$Na_i, _intracellular_ion_concentrations$Ca_i, '\
+            '_intracellular_ion_concentrations$K_i, _intracellular_Ca_buffering$O_C, '\
+            '_intracellular_Ca_buffering$O_TC, _intracellular_Ca_buffering$O_TMgC, '\
+            '_intracellular_Ca_buffering$O_TMgMg, _cleft_space_ion_concentrations$K_c, '\
+            '_Ca_handling_by_the_SR$Ca_rel, _Ca_handling_by_the_SR$Ca_up, _Ca_handling_by_the_SR$O_Calse, '\
+            '_Ca_handling_by_the_SR$F1, _Ca_handling_by_the_SR$F2, _Ca_handling_by_the_SR$F3]'

--- a/tests/test_state_symbols.py
+++ b/tests/test_state_symbols.py
@@ -36,9 +36,10 @@ class TestStateSymbols:
             '_Ca_independent_transient_outward_K_current_s3_gate$s3, _delayed_rectifier_K_current_z_gate$z, '\
             '_delayed_rectifier_K_current_pa_gate$p_a, _delayed_rectifier_K_current_pi_gate$p_i, '\
             '_intracellular_ion_concentrations$Na_i, _intracellular_ion_concentrations$K_i, '\
-            '_intracellular_ion_concentrations$Ca_i, _intracellular_Ca_buffering$O_C, _intracellular_Ca_buffering$O_TC,'\
-            ' _intracellular_Ca_buffering$O_TMgC, _intracellular_Ca_buffering$O_TMgMg, '\
-            '_cleft_space_ion_concentrations$K_c, _Ca_handling_by_the_SR$O_Calse, _Ca_handling_by_the_SR$Ca_rel, '\
+            '_intracellular_ion_concentrations$Ca_i, _intracellular_Ca_buffering$O_C, '\
+            '_intracellular_Ca_buffering$O_TC, _intracellular_Ca_buffering$O_TMgC, '\
+            '_intracellular_Ca_buffering$O_TMgMg, _cleft_space_ion_concentrations$K_c, '\
+            '_Ca_handling_by_the_SR$O_Calse, _Ca_handling_by_the_SR$Ca_rel, '\
             '_Ca_handling_by_the_SR$Ca_up, _Ca_handling_by_the_SR$F1, _Ca_handling_by_the_SR$F2, '\
             '_Ca_handling_by_the_SR$F3]'
         assert str(state_symbols_ordered_by_input) == \


### PR DESCRIPTION
added functionality to be able to order state variables in the order they were added to the model (rather than how they appear in equations). While this may seem pointless, this is required in order to get state variables in the same order as PyCML. Otherwise not just regression testing is difficult, but more importantly models generated will be incompatible (and fail existing chaste checks).

The code adds a `order_added` to dummy metadata (which is like an index) and sorts the state variables by this, if `order_by_order_added` flag is set (False by default)

Fixes #95