### PR TITLE
Make cellmlmanip compatible with Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - PIN_REQUIREMENTS=1
   - PIN_REQUIREMENTS=0
 python:
+  - "3.5"
   - "3.6"
 matrix:
   # Failures here don't mark the build as failed

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -15,9 +15,10 @@ class Transpiler(object):
     """
     Handles conversion of MathmL to Sympy exprerssions.
 
-    :param dummify: A bool that ???
-    :param symbol_prefix: A str that ???
-    :param symbol_lookup: A dict mapping ..?
+    :param dummify: Set to ``True`` to create dummy symbols for variables instead of sympy Symbols
+    :param symbol_prefix: An optional prefix to add to all symbols
+    :param symbol_lookup: A dict mapping variable names (including the optional ``symbol_prefix``) to
+        predefined Symbol or Dummy objects
     """
 
     def __init__(self, dummify=False, symbol_prefix=None, symbol_lookup=dict()):

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -10,7 +10,6 @@ import sympy
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class Transpiler(object):

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -3,7 +3,6 @@
 Content Markup specification: https://www.w3.org/TR/MathML2/chapter4.html
 """
 import logging
-from typing import Dict, List
 from xml.dom import Node, minidom
 
 import sympy
@@ -67,7 +66,7 @@ class Transpiler(object):
         for tag_name in SIMPLE_MATHML_TO_SYMPY_NAMES:
             self.handlers[tag_name] = self._simple_operator_handler
 
-    def parse_string(self, xml_string) -> List[sympy.Expr]:
+    def parse_string(self, xml_string):
         """
         Reads MathML content from a string and returns equivalent SymPy expressions.
         :return: A list of SymPy expressions.

--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -14,20 +14,23 @@ logger.setLevel(logging.INFO)
 
 
 class Transpiler(object):
-    """Transpiler class handles conversion of MathmL to Sympy exprerssions"""
+    """
+    Handles conversion of MathmL to Sympy exprerssions.
 
-    def __init__(self,
-                 dummify: bool = False,
-                 symbol_prefix: str = None,
-                 symbol_lookup=dict()) -> None:
+    :param dummify: A bool that ???
+    :param symbol_prefix: A str that ???
+    :param symbol_lookup: A dict mapping ..?
+    """
+
+    def __init__(self, dummify=False, symbol_prefix=None, symbol_lookup=dict()):
         # we create symbols as necessary, as they occur in equations
         self.error_on_unknown_symbol = False
 
         # create dummy symbols for variables rather than typical sympy symbols
-        self.dummify: bool = dummify
+        self.dummify = dummify
 
         # use to store information about dummified numbers (number & units)
-        self.metadata: Dict = dict()
+        self.metadata = dict()
 
         # prefix all symbols with given string
         self.symbol_prefix = symbol_prefix
@@ -66,28 +69,31 @@ class Transpiler(object):
             self.handlers[tag_name] = self._simple_operator_handler
 
     def parse_string(self, xml_string) -> List[sympy.Expr]:
-        """Reads MathML content from a string and returns equivalent SymPy expressions
+        """
+        Reads MathML content from a string and returns equivalent SymPy expressions.
+        :return: A list of SymPy expressions.
         """
         dom = minidom.parseString(xml_string)
         return self.parse_dom(dom.childNodes[0])
 
-    def parse_dom(self, math_dom_element) -> List[sympy.Expr]:
+    def parse_dom(self, math_dom_element):
         """Accepts a <math> node of DOM structure and returns equivalent SymPy expressions.
+
         Note: math_dom_element must point the <math> XmlNode, not the root XmlDocument
 
         :param math_dom_element: <math> XmlNode object of a MathML DOM structure
-        :return: List of SymPy expression(s)
+        :return: A list of SymPy expressions.
         """
         return self.transpile(math_dom_element)
 
     def transpile(self, xml_node):
         """Descends the given MathML element node and calls the corresponding handler for child
-        elements. Returns the SymPy expression of node
+        elements and returns the SymPy expression of node.
         :param xml_node: a DOM element of parsed MathML
         :return: a list of SymPy expressions
         """
         # Collect the parsed expression(s) (i.e. SymPy output) into list
-        sympy_expressions: List[sympy.Expr] = []
+        sympy_expressions = []
 
         # For each child element of this DOM node
         for child_node in xml_node.childNodes:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -499,14 +499,13 @@ class Model(object):
 
     def get_state_symbols(self, order_by_order_added=False):
         """Returns a list of state variables found in the given model graph.
-        order_by_order_added indicates whether state_symbols are sorted in the order they appear in the model
-        (otherwise ordering is determined by the order in equations)
+
+        :param order_by_order_added: indicates whether state_symbols are sorted in the order they appear in the model.
         """
         state_symbols = [v.args[0] for v in self.get_derivative_symbols()]
-        if not order_by_order_added:
-            return state_symbols
-        else:
+        if order_by_order_added:
             return sorted(state_symbols, key=lambda state_var: self.get_meta_dummy(state_var).order_added)
+        return state_symbols
 
     def get_free_variable_symbol(self):
         """Returns the free variable of the given model graph.

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -2,7 +2,6 @@
 import logging
 from collections import OrderedDict
 from io import StringIO
-from typing import Dict, List, Union
 
 import networkx as nx
 import rdflib
@@ -25,7 +24,7 @@ class MetaDummy(object):
 
     Dummy symbols are used to represent variables from the CellMl model or as placeholders for numbers.
     """
-    #TODO Add param list in docstring above
+    # TODO Add param list in docstring above
 
     def __init__(self, name, units, dummy, initial_value=None,
                  public_interface=None, private_interface=None, number=None,
@@ -118,7 +117,7 @@ class Model(object):
         assert isinstance(equation, sympy.Eq), 'Equation expression must be equality'
         self.equations.append(equation)
 
-    #TODO: Do we need the * here?
+    # TODO: Do we need the * here?
     def add_number(self, *, number, units, dummy=None):
         """
         Add metadata about a dummy symbol that represents a number in equations.
@@ -147,7 +146,7 @@ class Model(object):
 
         return self.dummy_metadata[dummy].dummy
 
-    #TODO: Do we need the * here?
+    # TODO: Do we need the * here?
     def add_variable(self, *, name, units, initial_value=None,
                      public_interface=None, private_interface=None, **kwargs):
         """

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -13,7 +13,6 @@ from cellmlmanip.units import UnitStore
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 # Delimiter for variables name in Sympy expressions: <component><delimiter><name>

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -21,9 +21,12 @@ SYMPY_SYMBOL_DELIMITER = '$'
 
 
 class MetaDummy(object):
-    """Holds information about a Dummy placeholder in set of Sympy equations. Dummy symbols are
-    used to represent variables from the CellMl model or as placeholders for numbers.
     """
+    Holds information about a Dummy placeholder in set of Sympy equations.
+
+    Dummy symbols are used to represent variables from the CellMl model or as placeholders for numbers.
+    """
+    #TODO Add param list in docstring above
 
     def __init__(self, name, units, dummy, initial_value=None,
                  public_interface=None, private_interface=None, number=None,
@@ -64,7 +67,7 @@ class MetaDummy(object):
         """Indicates whether this dummy instance is used as a placeholder for a number"""
         return self.number is not None
 
-    def __str__(self) -> str:
+    def __str__(self):
         return '%s(%s)' % (
             type(self).__name__,
             ', '.join('%s=%s' % item for item in vars(self).items() if item[1] is not None)
@@ -74,23 +77,32 @@ class MetaDummy(object):
 class Model(object):
     """An unrolled representation of a CellML model, using list of equations and metadata
     (e.g. units) about symbols used in those equations
+
+    :param name: the name of the model e.g. from <model name="">
     """
-    def __init__(self, name: str) -> None:
-        """Create a new instance of Model object
-        :param name: the name of the model e.g. from <model name="">
+    def __init__(self, name):
+
+        self.name = name
+        self.units = UnitStore(model=self)
+        self.rdf = rdflib.Graph()
+        self.graph = None   # An nx.DiGraph
+
+        # Maps sympy.Dummy objects to MetaDummy objects
+        self.dummy_metadata = OrderedDict()
+
+        # Maps string names to sympy.Dummy objects
+        self.name_to_symbol = dict()
+
+        # A list of sympy.Eq objects.
+        self.equations = []
+
+    def add_unit(self, units_name, unit_attributes=None, base_units=False):
         """
-        self.name: str = name
-        self.units: 'UnitStore' = UnitStore(model=self)
-        self.rdf: rdflib.Graph = rdflib.Graph()
-        self.graph: nx.DiGraph = None
+        Adds information about <units> in <model>
 
-        self.dummy_metadata: Dict[sympy.Dummy, MetaDummy] = OrderedDict()
-        self.name_to_symbol: Dict[str, sympy.Dummy] = dict()
-
-        self.equations: List[sympy.Eq] = list()
-
-    def add_unit(self, units_name: str, unit_attributes: List[Dict] = None, base_units=False):
-        """Adds information about <units> in <model>
+        :param units_name: A string name
+        :param unit_attributes: An optional list of dictionaries containing ???
+        :base_units: An optional bool that determines ???
         """
         assert not (unit_attributes and base_units), 'Cannot define base unit with unit attributes'
         if base_units:
@@ -98,15 +110,26 @@ class Model(object):
         else:
             self.units.add_custom_unit(units_name, unit_attributes)
 
-    def add_equation(self, equation: sympy.Eq):
-        """Add an equation to this model. Equation must be a Sympy equality"""
+    def add_equation(self, equation):
+        """
+        Adds an equation to this model.
+
+        :param equation: A ``sympy.Eq`` object.
+        """
         assert isinstance(equation, sympy.Eq), 'Equation expression must be equality'
         self.equations.append(equation)
 
-    def add_number(self, *,
-                   number: sympy.Number, units: str, dummy: sympy.Dummy = None) -> sympy.Dummy:
-        """Add metadata about a dummy symbol that represents a number in equations. Returns the
-        sympy.Dummy object used to represent this number"""
+    #TODO: Do we need the * here?
+    def add_number(self, *, number, units, dummy=None):
+        """
+        Add metadata about a dummy symbol that represents a number in equations.
+
+        :param number: A ``sympy.Number``.
+        :param units: A string unit representation.
+        :param dummy: An optional ``sympy.Dummy``.
+
+        :return: The ``sympy.Dummy`` object used to represent this number.
+        """
         assert isinstance(number, sympy.Number)
 
         # Create a dummy object if necessary
@@ -125,11 +148,21 @@ class Model(object):
 
         return self.dummy_metadata[dummy].dummy
 
-    def add_variable(self, *,
-                     name: str, units: str, initial_value=None,
-                     public_interface=None, private_interface=None, **kwargs) -> sympy.Dummy:
-        """Add information about a variable that represents a symbol in equations. Returns the
-        sympy.Dummy created by the model to represent the variable in equations"""
+    #TODO: Do we need the * here?
+    def add_variable(self, *, name, units, initial_value=None,
+                     public_interface=None, private_interface=None, **kwargs):
+        """
+        Add information about a variable that represents a symbol in equations.
+
+        :param name: A string name.
+        :param units: A string units reprensetation.
+        :param initial_value: An optional initial value.
+        :param public_interface: An optional public interface specifier.
+        :param private_interface: An optional private interface specifier.
+        :param kwargs: Any further keyword arguments will be passed to the :class:`MetaDummy` constructor.
+
+        :return: The ``sympy.Dummy`` created by the model to represent the variable in equations.
+        """
         assert name not in self.name_to_symbol, 'Variable %s already exists' % name
 
         dummy = sympy.Dummy(name)
@@ -151,8 +184,13 @@ class Model(object):
 
         return self.dummy_metadata[dummy].dummy
 
-    def get_meta_dummy(self, name_or_instance: Union[str, sympy.Dummy]) -> MetaDummy:
-        """Look up dummy data for given symbol. Accepts a string name or instance of sympy.Dummy"""
+    def get_meta_dummy(self, name_or_instance):
+        """
+        Look up dummy data for given symbol.
+
+        :param name_or_instance: A string name or a ``sympy.Dummy``.
+        :return: A :class:`MetaDummy`.
+        """
         if isinstance(name_or_instance, str):
             return self.dummy_metadata[self.name_to_symbol[name_or_instance]]
 
@@ -160,9 +198,11 @@ class Model(object):
         return self.dummy_metadata[name_or_instance]
 
     def check_dummy_metadata(self):
-        """Check that every symbol in list of equations has a metadata entry. Returns two lists:
-        ({set of dummy instances}, {dummy instances without metadata entry}"""
+        """
+        Check that every symbol in list of equations has a metadata entry.
 
+        :return: A set of dummy instances and a set of dummy instances without metadata.
+        """
         # collect list of all dummy instances
         dummy_instances = set()
         not_found = set()
@@ -280,21 +320,25 @@ class Model(object):
         """
         self.rdf.parse(StringIO(rdf))
 
-    def check_left_right_units_equal(self, equality: sympy.Eq):
-        """Given a Sympy Equality expression, checks that the LHS and RHS have the same units"""
-        rhs: sympy.Expr = equality.rhs
-        lhs: sympy.Expr = equality.lhs
-
-        lhs_units = self.units.summarise_units(lhs)
-        rhs_units = self.units.summarise_units(rhs)
+    def check_left_right_units_equal(self, equality):
+        """
+        Checks whether the LHS and RHS in a ``sympy.Eq`` have the same units.
+        :param equality: A ``sympy.Eq``.
+        """
+        lhs_units = self.units.summarise_units(equality.lhs)
+        rhs_units = self.units.summarise_units(equality.rhs)
 
         assert self.units.is_unit_equal(rhs_units, lhs_units), 'Units %s %s != %s %s' % (
             lhs_units, self.units.ureg.get_base_units(lhs_units),
             rhs_units, self.units.ureg.get_base_units(rhs_units)
         )
 
-    def get_equation_graph(self, refresh=False) -> nx.DiGraph:
-        """Returns an ordered list of equations for the model"""
+    def get_equation_graph(self, refresh=False):
+        """
+        Returns an ordered list of equations for the model
+
+        :return: An ``nx.Digraph`` of equations.
+        """
         # TODO: Set the parameters of the model (parameters rather than use initial values)
 
         # if we already have generated the equation graph

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -96,11 +96,12 @@ class Model(object):
 
     def add_unit(self, units_name, unit_attributes=None, base_units=False):
         """
-        Adds information about <units> in <model>
+        Adds information about <units> in <model>.
 
         :param units_name: A string name
-        :param unit_attributes: An optional list of dictionaries containing ???
-        :base_units: An optional bool that determines ???
+        :param unit_attributes: An optional list of dictionaries containing unit attributes. See
+            :meth:`UnitStore.add_custom_unit()`.
+        :base_units: Set to ``True`` to define a new base unit.
         """
         assert not (unit_attributes and base_units), 'Cannot define base unit with unit attributes'
         if base_units:
@@ -117,7 +118,6 @@ class Model(object):
         assert isinstance(equation, sympy.Eq), 'Equation expression must be equality'
         self.equations.append(equation)
 
-    # TODO: Do we need the * here?
     def add_number(self, *, number, units, dummy=None):
         """
         Add metadata about a dummy symbol that represents a number in equations.

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -5,6 +5,7 @@ handled by RDFLib.
 import itertools
 from collections import OrderedDict, deque
 from enum import Enum
+
 from lxml import etree
 
 from cellmlmanip import mathml2sympy

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -5,8 +5,6 @@ handled by RDFLib.
 import itertools
 from collections import OrderedDict, deque
 from enum import Enum
-
-import sympy
 from lxml import etree
 
 from cellmlmanip import mathml2sympy

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -5,7 +5,6 @@ handled by RDFLib.
 import itertools
 from collections import OrderedDict, deque
 from enum import Enum
-from typing import Dict
 
 import sympy
 from lxml import etree

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -60,20 +60,25 @@ class Parser(object):
         """Returns an ElementTree-friendly name with namespace in brackets"""
         return '{%s}%s' % (ns_enum.value, name)
 
-    def __init__(self, filepath: str) -> None:
+    def __init__(self, filepath):
         """Initialise an instance of Parser
 
         :param filepath: the full filepath to the CellML model file
         """
-        self.filepath: str = filepath
-        self.model: Model = None
-        self.components: Dict[str, _Component] = OrderedDict()
+        self.filepath = filepath
 
-    def parse(self) -> Model:
-        """The main method that reads the XML file and extract the relevant parts of CellML model
-        definition. Parser class should have been instantiated with the filepath.
+        # A :class:`Model` object or None
+        self.model = None
 
-        :return: a Model class holding CellML model definition, reading for manipulation
+        # A dictionary mapping component names to _Component objects
+        self.components = OrderedDict()
+
+    def parse(self):
+        """
+        The main method that reads the XML file and extracts the relevant parts of the CellML model
+        definition.
+
+        :return: a :class:`Model` holding CellML model definition, reading for manipulation.
         """
         tree = etree.parse(self.filepath)
 
@@ -95,15 +100,20 @@ class Parser(object):
     def _get_variable_name(component_name, variable_name):
         return component_name + SYMPY_SYMBOL_DELIMITER + variable_name
 
-    def _add_rdf(self, element: etree.Element):
-        """Finds all <RDF> definitions under <element> and adds them to the model
+    def _add_rdf(self, element):
+        """
+        Finds all ``<RDF>`` definitions under ``<element>`` and adds them to the model.
+
         :param element: the CellML parent element to search for children RDF tags
         """
         for rdf in element.iter(Parser.with_ns(XmlNs.RDF, 'RDF')):
             self.model.add_rdf(etree.tostring(rdf, encoding=str))
 
-    def _add_units(self, model: etree.Element):
-        """  <model> <units> <unit /> </units> </model> """
+    def _add_units(self, model):
+        """
+        <model> <units> <unit /> </units> </model>
+        :param model: an etree.Element
+        """
         units_elements = model.findall(Parser.with_ns(XmlNs.CELLML, 'units'))
 
         # get list of built-in cellml units
@@ -153,8 +163,11 @@ class Parser(object):
                 raise ValueError('Cannot create units %s. '
                                  'Cycles or unknown units.' % definitions_to_add)
 
-    def _add_components(self, model: etree.Element):
-        """ <model> <component> </model> """
+    def _add_components(self, model):
+        """
+        <model> <component> </model>
+        :param model: an etree.Element
+        """
         component_elements = model.findall(Parser.with_ns(XmlNs.CELLML, 'component'))
 
         # for each component defined in the model
@@ -168,15 +181,18 @@ class Parser(object):
             # process the <math> tags in this component
             self._add_maths(element, variable_to_symbol)
 
-    def _add_variables(self, component_element: etree.Element):
-        """ <model> <component> <variable> </component> </model> """
+    def _add_variables(self, component_element):
+        """
+        <model> <component> <variable> </component> </model>
+        :param component_element: an etree.Element
+        """
         variable_elements = component_element.findall(Parser.with_ns(XmlNs.CELLML, 'variable'))
 
         # we keep a {variable name: sympy symbol} lookup that we pass to mathml2sympy
         variable_lookup_symbol = dict()
 
         for variable_element in variable_elements:
-            attributes: Dict = dict(variable_element.attrib)
+            attributes = dict(variable_element.attrib)
 
             # Rename key for cmeta_id (remove namespace from attribute)
             cmeta_id_attribute = Parser.with_ns(XmlNs.CMETA, 'id')
@@ -192,9 +208,13 @@ class Parser(object):
 
         return variable_lookup_symbol
 
-    def _add_maths(self,
-                   component_element: etree.Element, variable_to_symbol: Dict[str, sympy.Dummy]):
-        """ <model> <component> <math> </component> </model> """
+    def _add_maths(self, component_element, variable_to_symbol):
+        """
+        <model> <component> <math> </component> </model>
+
+        :param component_element: an etree.Element
+        :param variable_to_symbol: a ``Dict[str, sympy.Dummy]``
+        """
         # get all <math> elements in the component
         math_elements = component_element.findall(Parser.with_ns(XmlNs.MATHML, 'math'))
 
@@ -269,7 +289,10 @@ class Parser(object):
                 if component_a != component_b:
                     self.components[component_a].add_sibling(component_b)
 
-    def _add_connection(self, model: etree.Element):
+    def _add_connection(self, model):
+        """
+        :param model: an etree.Element
+        """
         connection_elements = model.findall(Parser.with_ns(XmlNs.CELLML, 'connection'))
 
         # a list to collect the (source, target) connection tuples

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -166,9 +166,8 @@ class UnitStore(object):
         """Initialise a UnitStore instance; wraps the unit registry and handles addition of new
         unit definitions"""
         cellml_unit_definition = os.path.join(
-            os.path.dirname(__file__), 'cellml_units.txt'
-        )
-        self.ureg: pint.UnitRegistry = pint.UnitRegistry(cellml_unit_definition)
+            os.path.dirname(__file__), 'cellml_units.txt')
+        self.ureg = pint.UnitRegistry(cellml_unit_definition)
 
         # units that are defined and added to the unit registry, on top of default cellml units
         self.custom_defined = set()
@@ -202,8 +201,10 @@ class UnitStore(object):
             self._define_pint_unit(units_name, unit_definition)
 
     def add_preferred_custom_unit_name(self, units_name, unit_attributes):
-        """Set a prefered name for all equivalent custom units. If it does not exist yet, also define a new Pint unit
-        definition to the unit registry.
+        """
+        Set a prefered name for all equivalent custom units.
+
+        If the unit does not exist yet, also define a new Pint unit definition to the unit registry.
         PLEASE NOTE: not retrospective, assumes you are not adding new expressions to the model.
         It also does not do any unit conversions, only works on equivalent units with different names.
         :param units_name: the prefered name for this unit and all units in the model that are equivalent
@@ -242,20 +243,23 @@ class UnitStore(object):
         self.ureg.define(definition_string_or_instance)
         self.custom_defined.add(units_name)
 
-    def get_quantity(self, unit_name: str):
+    def get_quantity(self, unit_name):
         """Returns a pint.Unit with the given name from the UnitRegistry.
         :param unit_name: string name of the unit
         :return: pint.Unit
         throws pint.UndefinedUnitError if te unit is not present in registry
         """
         try:
-            resolved_unit = self.ureg.parse_expression(unit_name).units
-            return resolved_unit
+            return self.ureg.parse_expression(unit_name).units
         except pint.UndefinedUnitError:
             raise KeyError('Cannot find unit <%s> in unit registry' % unit_name)
 
-    def _make_pint_unit_definition(self, units_name, unit_attributes: List[Dict]):
-        """Uses the CellML definition to construct a Pint unit definition string
+    def _make_pint_unit_definition(self, units_name, unit_attributes):
+        """
+        Uses a CellML definition to construct a Pint unit definition string.
+
+        :param units_name: The unit name
+        :param unit_attributes: A list of dictionaries. See :meth:`add_custom_unit`.
         """
         full_unit_expr = []
 
@@ -319,7 +323,7 @@ class UnitStore(object):
         assert isinstance(unit, self.ureg.Unit)
         return quantity.to(unit)
 
-    def summarise_units(self, expr: sympy.Expr):
+    def summarise_units(self, expr):
         """Given a Sympy expression, will get the lambdified string to evaluate units.
         Note the call to UnitCalculator:traverse will throw an error if units are bad or cannot be calculated.
         :param expr: the Sympy expression on which to evaluate units
@@ -362,14 +366,18 @@ class UnitStore(object):
 
 
 class UnitCalculator(object):
-    """Evaluates a Sympy expression to determine its units. Note: only supports subset of Sympy
-    math"""
+    """
+    Evaluates a Sympy expression to determine its units.
+
+    Note: only supports subset of Sympy math.
+    """
     def __init__(self, unit_registry, dummy_metadata):
         """ Initialises teh UnitCalculator class
         :param unit_registry: instance of Pint UnitRegistry
         :param dummy_metadata: a dictionary providing {dummy: MetaDummy} lookup
         """
-        self.ureg: pint.UnitRegistry = unit_registry
+        # A pint.UnitRegistry
+        self.ureg = unit_registry
         self.dummy_metadata = dummy_metadata
 
     def _check_unit_of_quantities_equal(self, list_of_quantities):
@@ -395,8 +403,9 @@ class UnitCalculator(object):
     def _is_dimensionless(self, quantity):
         return quantity.units.dimensionality == self.ureg.dimensionless.dimensionality
 
-    def traverse(self, expr: sympy.Expr):
+    def traverse(self, expr):
         """Descends the Sympy expression and performs Pint unit arithmetic on sub-expressions
+
         :param expr: a Sympy expression
         :returns: the quantity (i.e. magnitude(expression) * unit) of the expression
         :throws: KeyError - if variable not found in metadata
@@ -622,7 +631,7 @@ class UnitCalculator(object):
 
 
 class ExpressionWithUnitPrinter(LambdaPrinter):
-    """Sympy expression printer to print expressions with unit information """
+    """Sympy expression printer to print expressions with unit information."""
     def __init__(self, symbol_info):
         """
         Initialises the ExpressionWithUnitPrinter

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -17,7 +17,7 @@ from sympy.printing.lambdarepr import LambdaPrinter
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+
 
 # The full list of supported CellML units
 # Taken from https://www.cellml.org/specifications/cellml_1.1/#sec_units

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -7,7 +7,6 @@ import numbers
 import os
 from functools import reduce
 from operator import mul
-from typing import Dict, List
 
 import pint
 import sympy

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ ignore =
     W503  # break before binary operator - allow either style
     W504  # break after binary operator - allow either style
 exclude =
+  .git,
+  venv
 
 [isort]
 line_length = 100

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 with open('README.md') as f:
     readme = f.read()

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'cellmlmanip': ['cellml_units.txt']},
     include_package_data=True,
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     install_requires=[
         'lxml>=4',
         'networkx>=2',

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -139,7 +139,7 @@ class TestHodgkin:
         state_symbols_ordered_by_input = model.get_state_symbols(order_by_order_added=True)
         assert len(state_symbols) == len(state_symbols_ordered_by_input) == 4
         assert set(state_symbols) == set(state_symbols_ordered_by_input)
-        assert str(state_symbols) == str(state_symbols_ordered_by_input) == \
+        assert str(state_symbols_ordered_by_input) == \
             '[_membrane$V, _sodium_channel_m_gate$m, _sodium_channel_h_gate$h, _potassium_channel_n_gate$n]'
 
     def test_free_variable_symbol(self, model):
@@ -301,13 +301,19 @@ class TestHodgkin:
                            sympy.Dummy('sodium_channel$E_Na')))
                   ]
 
-        # Expected ordering for not lexicographical sorted equations
-        unordered_ref_eq = [ref_eq[2], ref_eq[0], ref_eq[1], ref_eq[3]]
-
         # Check equations against expected equations
         for i in range(len(equations)):
             assert str(equations[i]) == str(ref_eq[i])
 
+        #TODO: This test is flawed: The topographical order is
+        # non-unique, and so non-deterministic. We have to check if certain
+        # elements are before others instead.
+        # See: https://networkx.github.io/documentation/networkx-2.3/
+        #       reference/algorithms/generated/networkx.algorithms.dag.topological_sort.html
+
+        # Expected ordering for topographically sorted equations
+        #unordered_ref_eq = [ref_eq[2], ref_eq[0], ref_eq[1], ref_eq[3]]
+
         # Check not lexicographical sorted equations against expected equations
-        for i in range(len(unordered_equations)):
-            assert str(unordered_equations[i]) == str(unordered_ref_eq[i])
+        #for i in range(len(unordered_equations)):
+        #    assert str(unordered_equations[i]) == str(unordered_ref_eq[i])

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -6,6 +6,7 @@ import sympy
 
 from cellmlmanip import load_model
 
+
 OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
 

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -305,15 +305,16 @@ class TestHodgkin:
         for i in range(len(equations)):
             assert str(equations[i]) == str(ref_eq[i])
 
-        #TODO: This test is flawed: The topographical order is
+        # TODO: This test is flawed: The topographical order is
         # non-unique, and so non-deterministic. We have to check if certain
         # elements are before others instead.
         # See: https://networkx.github.io/documentation/networkx-2.3/
         #       reference/algorithms/generated/networkx.algorithms.dag.topological_sort.html
-
+        '''
         # Expected ordering for topographically sorted equations
-        #unordered_ref_eq = [ref_eq[2], ref_eq[0], ref_eq[1], ref_eq[3]]
+        unordered_ref_eq = [ref_eq[2], ref_eq[0], ref_eq[1], ref_eq[3]]
 
         # Check not lexicographical sorted equations against expected equations
-        #for i in range(len(unordered_equations)):
-        #    assert str(unordered_equations[i]) == str(unordered_ref_eq[i])
+        for i in range(len(unordered_equations)):
+            assert str(unordered_equations[i]) == str(unordered_ref_eq[i])
+        '''

--- a/tests/test_model_bad_units.py
+++ b/tests/test_model_bad_units.py
@@ -1,8 +1,8 @@
-import pytest
 import os
 
-from cellmlmanip import parser
-from cellmlmanip import units
+import pytest
+
+from cellmlmanip import parser, units
 
 
 class TestModelBadUnits:
@@ -41,4 +41,3 @@ class TestModelBadUnits:
         # this does raise an error
         with pytest.raises(units.UnitError):
             model.units.summarise_units(equation[1].rhs)
-

--- a/tests/test_model_units.py
+++ b/tests/test_model_units.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 from cellmlmanip import parser
 

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -6,6 +6,7 @@ import sympy
 import cellmlmanip
 import cellmlmanip.rdf
 
+
 OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
 

--- a/tests/test_state_symbols.py
+++ b/tests/test_state_symbols.py
@@ -4,6 +4,7 @@ import pytest
 
 from cellmlmanip import load_model
 
+
 OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
 

--- a/tests/test_state_symbols.py
+++ b/tests/test_state_symbols.py
@@ -27,21 +27,6 @@ class TestStateSymbols:
         state_symbols = model.get_state_symbols()
         state_symbols_ordered_by_input = model.get_state_symbols(order_by_order_added=True)
         assert len(state_symbols) == len(state_symbols_ordered_by_input) == 29
-        assert str(state_symbols) == \
-            '[_membrane$V, _sodium_current_m_gate$m, _sodium_current_h1_gate$h1, _sodium_current_h2_gate$h2, '\
-            '_L_type_Ca_channel_d_L_gate$d_L, _L_type_Ca_channel_f_L_gate$f_L, _T_type_Ca_channel_d_T_gate$d_T, '\
-            '_T_type_Ca_channel_f_T_gate$f_T, _Ca_independent_transient_outward_K_current_r_gate$r, '\
-            '_Ca_independent_transient_outward_K_current_s1_gate$s1, '\
-            '_Ca_independent_transient_outward_K_current_s2_gate$s2, '\
-            '_Ca_independent_transient_outward_K_current_s3_gate$s3, _delayed_rectifier_K_current_z_gate$z, '\
-            '_delayed_rectifier_K_current_pa_gate$p_a, _delayed_rectifier_K_current_pi_gate$p_i, '\
-            '_intracellular_ion_concentrations$Na_i, _intracellular_ion_concentrations$K_i, '\
-            '_intracellular_ion_concentrations$Ca_i, _intracellular_Ca_buffering$O_C, '\
-            '_intracellular_Ca_buffering$O_TC, _intracellular_Ca_buffering$O_TMgC, '\
-            '_intracellular_Ca_buffering$O_TMgMg, _cleft_space_ion_concentrations$K_c, '\
-            '_Ca_handling_by_the_SR$O_Calse, _Ca_handling_by_the_SR$Ca_rel, '\
-            '_Ca_handling_by_the_SR$Ca_up, _Ca_handling_by_the_SR$F1, _Ca_handling_by_the_SR$F2, '\
-            '_Ca_handling_by_the_SR$F3]'
         assert str(state_symbols_ordered_by_input) == \
             '[_membrane$V, _sodium_current_m_gate$m, _sodium_current_h1_gate$h1, _sodium_current_h2_gate$h2, '\
             '_L_type_Ca_channel_d_L_gate$d_L, _L_type_Ca_channel_f_L_gate$f_L, '\

--- a/tests/test_state_symbols.py
+++ b/tests/test_state_symbols.py
@@ -28,6 +28,7 @@ class TestStateSymbols:
         state_symbols = model.get_state_symbols()
         state_symbols_ordered_by_input = model.get_state_symbols(order_by_order_added=True)
         assert len(state_symbols) == len(state_symbols_ordered_by_input) == 29
+        assert set(state_symbols) == set(state_symbols_ordered_by_input)
         assert str(state_symbols_ordered_by_input) == \
             '[_membrane$V, _sodium_current_m_gate$m, _sodium_current_h1_gate$h1, _sodium_current_h2_gate$h2, '\
             '_L_type_Ca_channel_d_L_gate$d_L, _L_type_Ca_channel_f_L_gate$f_L, '\

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -1,6 +1,9 @@
-import pytest
 import os
+
+import pytest
+
 import cellmlmanip
+
 
 OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,16 +1,22 @@
-import pytest
-import sympy as sp
 import os
 from collections import OrderedDict
 
+import pytest
+import sympy as sp
+
 from cellmlmanip import load_model
 from cellmlmanip.model import MetaDummy
-from cellmlmanip.units import (ExpressionWithUnitPrinter, UnitCalculator,
-                               UnitStore, InputArgumentsInvalidUnitsError,
-                               InputArgumentsMustBeDimensionlessError,
-                               InputArgumentMustBeNumberError,
-                               BooleanUnitsError,
-                               UnexpectedMathUnitsError)
+from cellmlmanip.units import (
+    BooleanUnitsError,
+    ExpressionWithUnitPrinter,
+    InputArgumentMustBeNumberError,
+    InputArgumentsInvalidUnitsError,
+    InputArgumentsMustBeDimensionlessError,
+    UnexpectedMathUnitsError,
+    UnitCalculator,
+    UnitStore,
+)
+
 
 OXMETA = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 
@@ -434,4 +440,3 @@ class TestUnits(object):
         membrane_voltage = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
         assert model.units.dimensionally_equivalent(membrane_stimulus_current_offset, membrane_stimulus_current_period)
         assert not model.units.dimensionally_equivalent(membrane_stimulus_current_offset, membrane_voltage)
-

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,6 +1,7 @@
 import pytest
 import sympy as sp
 import os
+from collections import OrderedDict
 
 from cellmlmanip import load_model
 from cellmlmanip.model import MetaDummy
@@ -25,24 +26,23 @@ class TestUnits(object):
         return load_model(hodgkin_cellml)
 
     # These represent CellML <units><unit>...</unit></units> elements
-    test_definitions = {
-        'ms': [{'units': 'second', 'prefix': 'milli'}],
-        'per_ms': [{'units': 'ms', 'exponent': '-1'}],
-        'usec': [{'units': 'second', 'prefix': 'micro'}],
-        'mV': [{'units': 'volt', 'prefix': 'milli'}],
-        'per_mV': [{'units': 'volt', 'prefix': 'milli', 'exponent': '-1'}],
-        'uV': [{'units': 'volt', 'prefix': 'micro'}],
-        'mV_per_ms': [{'units': 'mV', 'exponent': '1'}, {'units': 'ms', 'exponent': '-1'}],
-        'mV_per_s': [{'units': 'mV', 'exponent': '1'}, {'units': 'second', 'exponent': '-1'}],
-        'mV_per_usec': [{'units': 'mV', 'exponent': '1'},
-                        {'prefix': 'micro', 'units': 'second', 'exponent': '-1'}],
-        'mM': [{'prefix': 'milli', 'units': 'mole'}, {'units': 'litre', 'exponent': '-1'}],
-        'mM_per_ms': [{'units': 'mM'}, {'units': 'ms', 'exponent': '-1'}],
-        'milli_mole': [{'prefix': 'milli', 'units': 'mole'}],
-        'millisecond': [{'prefix': 'milli', 'units': 'second'}],
-        'ms_power_prefix': [{'prefix': '-3', 'units': 'second'}],
-        'ms_with_multiplier': [{'multiplier': 0.001, 'units': 'second'}],
-    }
+    test_definitions = OrderedDict()
+    test_definitions['ms'] = [{'units': 'second', 'prefix': 'milli'}]
+    test_definitions['per_ms'] = [{'units': 'ms', 'exponent': '-1'}]
+    test_definitions['usec'] = [{'units': 'second', 'prefix': 'micro'}]
+    test_definitions['mV'] = [{'units': 'volt', 'prefix': 'milli'}]
+    test_definitions['per_mV'] = [{'units': 'volt', 'prefix': 'milli', 'exponent': '-1'}]
+    test_definitions['uV'] = [{'units': 'volt', 'prefix': 'micro'}]
+    test_definitions['mV_per_ms'] = [{'units': 'mV', 'exponent': '1'}, {'units': 'ms', 'exponent': '-1'}]
+    test_definitions['mV_per_s'] = [{'units': 'mV', 'exponent': '1'}, {'units': 'second', 'exponent': '-1'}]
+    test_definitions['mV_per_usec'] = [
+        {'units': 'mV', 'exponent': '1'}, {'prefix': 'micro', 'units': 'second', 'exponent': '-1'}]
+    test_definitions['mM'] = [{'prefix': 'milli', 'units': 'mole'}, {'units': 'litre', 'exponent': '-1'}]
+    test_definitions['mM_per_ms'] = [{'units': 'mM'}, {'units': 'ms', 'exponent': '-1'}]
+    test_definitions['milli_mole'] = [{'prefix': 'milli', 'units': 'mole'}]
+    test_definitions['millisecond'] = [{'prefix': 'milli', 'units': 'second'}]
+    test_definitions['ms_power_prefix'] = [{'prefix': '-3', 'units': 'second'}]
+    test_definitions['ms_with_multiplier'] = [{'multiplier': 0.001, 'units': 'second'}]
 
     @pytest.fixture(scope="class")
     def quantity_store(self):
@@ -434,3 +434,4 @@ class TestUnits(object):
         membrane_voltage = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
         assert model.units.dimensionally_equivalent(membrane_stimulus_current_offset, membrane_stimulus_current_period)
         assert not model.units.dimensionally_equivalent(membrane_stimulus_current_offset, membrane_voltage)
+

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -32,23 +32,26 @@ class TestUnits(object):
         return load_model(hodgkin_cellml)
 
     # These represent CellML <units><unit>...</unit></units> elements
-    test_definitions = OrderedDict()
-    test_definitions['ms'] = [{'units': 'second', 'prefix': 'milli'}]
-    test_definitions['per_ms'] = [{'units': 'ms', 'exponent': '-1'}]
-    test_definitions['usec'] = [{'units': 'second', 'prefix': 'micro'}]
-    test_definitions['mV'] = [{'units': 'volt', 'prefix': 'milli'}]
-    test_definitions['per_mV'] = [{'units': 'volt', 'prefix': 'milli', 'exponent': '-1'}]
-    test_definitions['uV'] = [{'units': 'volt', 'prefix': 'micro'}]
-    test_definitions['mV_per_ms'] = [{'units': 'mV', 'exponent': '1'}, {'units': 'ms', 'exponent': '-1'}]
-    test_definitions['mV_per_s'] = [{'units': 'mV', 'exponent': '1'}, {'units': 'second', 'exponent': '-1'}]
-    test_definitions['mV_per_usec'] = [
-        {'units': 'mV', 'exponent': '1'}, {'prefix': 'micro', 'units': 'second', 'exponent': '-1'}]
-    test_definitions['mM'] = [{'prefix': 'milli', 'units': 'mole'}, {'units': 'litre', 'exponent': '-1'}]
-    test_definitions['mM_per_ms'] = [{'units': 'mM'}, {'units': 'ms', 'exponent': '-1'}]
-    test_definitions['milli_mole'] = [{'prefix': 'milli', 'units': 'mole'}]
-    test_definitions['millisecond'] = [{'prefix': 'milli', 'units': 'second'}]
-    test_definitions['ms_power_prefix'] = [{'prefix': '-3', 'units': 'second'}]
-    test_definitions['ms_with_multiplier'] = [{'multiplier': 0.001, 'units': 'second'}]
+    test_definitions = OrderedDict({
+        'ms': [{'units': 'second', 'prefix': 'milli'}],
+        'usec': [{'units': 'second', 'prefix': 'micro'}],
+        'mV': [{'units': 'volt', 'prefix': 'milli'}],
+        'uV': [{'units': 'volt', 'prefix': 'micro'}],
+        'mM': [{'prefix': 'milli', 'units': 'mole'}, {'units': 'litre', 'exponent': '-1'}],
+        'milli_mole': [{'prefix': 'milli', 'units': 'mole'}],
+        'millisecond': [{'prefix': 'milli', 'units': 'second'}],
+    })
+    test_definitions.update({
+        'per_ms': [{'units': 'ms', 'exponent': '-1'}],
+        'per_mV': [{'units': 'volt', 'prefix': 'milli', 'exponent': '-1'}],
+        'mV_per_ms': [{'units': 'mV', 'exponent': '1'}, {'units': 'ms', 'exponent': '-1'}],
+        'mV_per_s': [{'units': 'mV', 'exponent': '1'}, {'units': 'second', 'exponent': '-1'}],
+        'mV_per_usec': [
+            {'units': 'mV', 'exponent': '1'}, {'prefix': 'micro', 'units': 'second', 'exponent': '-1'}],
+        'mM_per_ms': [{'units': 'mM'}, {'units': 'ms', 'exponent': '-1'}],
+        'ms_power_prefix': [{'prefix': '-3', 'units': 'second'}],
+        'ms_with_multiplier': [{'multiplier': 0.001, 'units': 'second'}],
+    })
 
     @pytest.fixture(scope="class")
     def quantity_store(self):


### PR DESCRIPTION
It's the default in ubuntu LTS 16 which has support until 2021, and 3.5 (and older!) will be used in university systems for long after.

In addition, checking on 3.5 I found a couple of instances where we relied on Python3.6 dict ordering, which we should never do, as this is an implementation artefact.