### PR TITLE
Replaced graph.node by graph.nodes (deprecated since networkx 2.1).

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -345,7 +345,7 @@ class Model(object):
             # for each of the symbols on the rhs of the equation
             for rhs_symbol in self.get_symbols_for([equation.rhs]):
                 # if the symbol maps to a node in the graph
-                if rhs_symbol in graph.node:
+                if rhs_symbol in graph.nodes:
                     # add the dependency edge
                     graph.add_edge(rhs_symbol, lhs_symbol)
                 else:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'lxml>=4',
-        'networkx>=2',
+        'networkx>=2.1',
         'pint>=0.8.1',
         'rdflib>=4',
         'sympy>=1.4',


### PR DESCRIPTION
See #102 