### PR TITLE
Made Model.graph a get-only property

### DIFF
--- a/cellmlmanip/main.py
+++ b/cellmlmanip/main.py
@@ -1,9 +1,8 @@
-"""Main entry-points and functions for interacting with the cellmlmanip library"""
+"""Main entry-points and functions for interacting with the cellmlmanip library."""
 from cellmlmanip.parser import Parser
 
 
 def load_model(path):
-    """Loads a cellml model."""
-    model = Parser(path).parse()
-    model.get_equation_graph()
-    return model
+    """Parses a CellML file and returns a :class:`cellmlmanip.Model`."""
+    return Parser(path).parse()
+

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -596,7 +596,7 @@ class Model(object):
             lhs = equation.lhs
 
             # for each of the symbols or derivatives on the rhs of the equation
-            for rhs in self._find_symbols_and_derivatives(equation.rhs):
+            for rhs in self.find_symbols_and_derivatives([equation.rhs]):
                 # if the symbol maps to a node in the graph
                 if rhs in graph.nodes:
                     # add the dependency edge

--- a/tests/test_aslanidi_model.py
+++ b/tests/test_aslanidi_model.py
@@ -19,13 +19,11 @@ class TestAslanidiModel:
         return load_model(cellml)
 
     def test_initial_value_capacitance(self, model):
-        model.get_equation_graph()
         membrane_capacitance = model.get_symbol_by_ontology_term(OXMETA, "membrane_capacitance")
         # was raising KeyError but should not
         assert(model.get_initial_value(membrane_capacitance) == 0.00005)
 
     def test_initial_value_voltage(self, model):
-        model.get_equation_graph()
         membrane_voltage = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
         assert(model.get_initial_value(membrane_voltage) == -80)
 

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -20,10 +20,6 @@ class TestHodgkin:
         )
         return load_model(hodgkin_cellml)
 
-    @pytest.fixture(scope="class")
-    def graph(self, model):
-        return model.get_equation_graph()
-
     def test_counts(self, model):
         # https://models.cellml.org/exposure/5d116522c3b43ccaeb87a1ed10139016/hodgkin_huxley_1952_variant01.cellml/cellml_math
         assert len(model.equations) == 17
@@ -52,7 +48,8 @@ class TestHodgkin:
         variable_assignment_ok = model.check_dummy_assignment()
         assert variable_assignment_ok
 
-    def test_equation_graph(self, graph, model):
+    def test_equation_graph(self, model):
+        graph = model.graph
         assert len(graph.nodes) == 32
 
         free_variable = model.find_variable({'type': 'free'})
@@ -148,7 +145,7 @@ class TestHodgkin:
         free_variable_symbol = model.get_free_variable_symbol()
         assert free_variable_symbol.name == 'environment$time'
 
-    def test_evaluation(self, graph, model):
+    def test_evaluation(self, model):
         """
         From Michael:
 
@@ -177,6 +174,7 @@ class TestHodgkin:
         (as in, converting to and back from string shouldn't lose
         accuracy, it does _not_ mean all printed digits are accurate)
         """
+        graph = model.graph_with_sympy_numbers
 
         # initial values for the free and state variables
         initials = {
@@ -246,7 +244,7 @@ class TestHodgkin:
             actual = evaluated_deriv
             assert float(actual) == pytest.approx(expected)
 
-    def test_get_symbol_by_ontology_term(self, graph, model):
+    def test_get_symbol_by_ontology_term(self, model):
         membrane_voltage_var = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
         assert (isinstance(membrane_voltage_var, sympy.symbol.Dummy))
         assert str(membrane_voltage_var) == "_membrane$V"
@@ -276,7 +274,7 @@ class TestHodgkin:
         # Repeat test without specifying namespace
         assert model.has_ontology_annotation(membrane_voltage_var)
 
-    def test_get_equations_for(self, graph, model):
+    def test_get_equations_for(self, model):
 
         # Test get_equations_for with topgraphical lexicographical ordering
 

--- a/tests/test_hodgkin.py
+++ b/tests/test_hodgkin.py
@@ -320,3 +320,16 @@ class TestHodgkin:
         # ENa and gNa should come before iNa
         assert unordered_equations.index(ENa) < unordered_equations.index(iNa)
         assert unordered_equations.index(gNa) < unordered_equations.index(iNa)
+
+    def test_get_equations_for_with_dummies(self, model):
+
+        # Tests using get_equations_for without replacing dummies with sympy numbers
+        # Get ordered equations
+        ina = model.get_symbol_by_ontology_term(OXMETA, 'membrane_fast_sodium_current')
+        equations = model.get_equations_for([ina], recurse=False, strip_units=False)
+
+        for eq in equations:
+            if eq.lhs.name == 'sodium_channel$g_Na':
+                assert isinstance(eq.rhs, sympy.Dummy)
+                break
+

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -98,8 +98,6 @@ class TestModelAPI(object):
     def test_find_symbols_and_derivatives(self, model):
         """ Tests Model.find_symbols_and_derivatives. """
 
-        model.get_equation_graph()
-
         # Test on single variable expressions
         t = model.get_free_variable_symbol()
         syms = model.find_symbols_and_derivatives([t])

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -47,15 +47,14 @@ class TestModelAPI(object):
         path = os.path.join(os.path.dirname(__file__), 'cellml_files', '4.algebraic_ode_model.cellml')
         model = parser.Parser(path).parse()
 
-        # But equation graph will raise error
+        # But equation graph will raise error (if accessed)
         with pytest.raises(RuntimeError, match='DAEs are not supported'):
-            model.get_equation_graph()
+            model.graph
 
     def test_set_equation(self, model):
         """ Tests replacing an equation in a model. """
 
         # Get model, assert that V is a state variable
-        model.get_equation_graph()
         v = model.get_symbol_by_ontology_term(OXMETA, 'membrane_voltage')
         v_meta = model.get_meta_dummy(v)
         assert v_meta.type == 'state'
@@ -66,7 +65,6 @@ class TestModelAPI(object):
         model.set_equation(v, rhs)
 
         # Check that V is no longer a state
-        model.get_equation_graph()
         v = model.get_symbol_by_ontology_term(OXMETA, 'membrane_voltage')
         v_meta = model.get_meta_dummy(v)
         assert v_meta.type != 'state'
@@ -88,7 +86,6 @@ class TestModelAPI(object):
         model.set_equation(lhs, rhs)
 
         # Check that V is a state again
-        model.get_equation_graph()
         v = model.get_symbol_by_ontology_term(OXMETA, 'membrane_voltage')
         v_meta = model.get_meta_dummy(v)
         assert v_meta.type == 'state'

--- a/tests/test_model_bad_units.py
+++ b/tests/test_model_bad_units.py
@@ -21,7 +21,6 @@ class TestModelBadUnits:
         return model
 
     def test_units(self, parser_instance, model):
-        model.get_equation_graph(True)  # set up the graph - it is not automatic
         symbol_a = model.get_symbol_by_cmeta_id("a")
         symbol_b = model.get_symbol_by_cmeta_id("b")
         equation = model.get_equations_for([symbol_b])

--- a/tests/test_model_units.py
+++ b/tests/test_model_units.py
@@ -21,14 +21,12 @@ class TestModelUnits:
         return model
 
     def test_symbols(self, parser_instance, model):
-        model.get_equation_graph(True)  # set up the graph - it is not automatic
         symbol = model.get_symbol_by_cmeta_id("a")
         assert symbol.is_Symbol
         symbol = model.get_symbol_by_cmeta_id("b")
         assert symbol.is_Symbol
 
     def test_equations(self, parser_instance, model):
-        model.get_equation_graph(True)  # set up the graph - it is not automatic
         symbol_a = model.get_symbol_by_cmeta_id("a")
         equation = model.get_equations_for([symbol_a])
         assert len(equation) == 1
@@ -36,7 +34,6 @@ class TestModelUnits:
         assert equation[0].rhs == 1.0
 
     def test_equations_2(self, parser_instance, model):
-        model.get_equation_graph(True)  # set up the graph - it is not automatic
         symbol_a = model.get_symbol_by_cmeta_id("a")
         symbol_b = model.get_symbol_by_cmeta_id("b")
         equation = model.get_equations_for([symbol_b])
@@ -47,7 +44,6 @@ class TestModelUnits:
         assert equation[1].rhs == 2.0 / symbol_a
 
     def test_units(self, parser_instance, model):
-        model.get_equation_graph(True)  # set up the graph - it is not automatic
         symbol_a = model.get_symbol_by_cmeta_id("a")
         equation = model.get_equations_for([symbol_a])
         assert model.units.summarise_units(equation[0].lhs) == 'ms'

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -109,8 +109,7 @@ def test_get_ontology_terms_by_symbol(test_bad_annotations):
     model = test_bad_annotations
 
     # Get v3 from the model, as it does not have cmeta_id, to test this part of the code
-    equation_graph = model.get_equation_graph()
-    for variable in equation_graph:
+    for variable in model.graph:
         if str(variable) == '_c$v3':
             annotations = model.get_ontology_terms_by_symbol(variable, OXMETA)
             assert len(annotations) == 0
@@ -121,8 +120,7 @@ def test_has_ontology_term_by_symbol(test_bad_annotations):
     model = test_bad_annotations
 
     # Get v3 from the model, as it does not have cmeta_id, to test this part of the code
-    equation_graph = model.get_equation_graph()
-    for variable in equation_graph:
+    for variable in model.graph:
         if str(variable) == '_c$v3':
             assert not model.has_ontology_annotation(variable, OXMETA)
 

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -31,7 +31,6 @@ def test_add_preferred_custom_unit_name(model):
 
 
 def test_conversion_factor_original(simple_model):
-    simple_model.get_equation_graph(True)  # set up the graph - it is not automatic
     symbol_b1 = simple_model.get_symbol_by_cmeta_id("b_1")
     equation = simple_model.get_equations_for([symbol_b1])
     factor = simple_model.units.get_conversion_factor(quantity=1 * simple_model.units.summarise_units(equation[0].lhs),
@@ -40,7 +39,6 @@ def test_conversion_factor_original(simple_model):
 
 
 def test_conversion_factor_bad_types(simple_model):
-    simple_model.get_equation_graph(True)  # set up the graph - it is not automatic
     symbol_b1 = simple_model.get_symbol_by_cmeta_id("b_1")
     equation = simple_model.get_equations_for([symbol_b1])
     expression = equation[0].lhs
@@ -76,7 +74,6 @@ def test_conversion_factor_bad_types(simple_model):
 
 
 def test_conversion_factor_same_units(simple_model):
-    simple_model.get_equation_graph(True)  # set up the graph - it is not automatic
     symbol_b = simple_model.get_symbol_by_cmeta_id("b")
     equation = simple_model.get_equations_for([symbol_b])
     expression = equation[1].rhs


### PR DESCRIPTION
- Model.graph is now a property, creates the graph if necessary
- There's a second property graph_with_sympy_numbers if you don't want the dummies (e.g. for evaluating expressions or code generation). get_equations_for() uses this by default
- The model invalidates its graph cache in every method where the equations are modified