### PR TITLE
Reverted change to Model.find_symbols_and_derivatives

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -415,7 +415,7 @@ class Model(object):
             lhs = equation.lhs
 
             # for each of the symbols or derivatives on the rhs of the equation
-            for rhs in self.find_symbols_and_derivatives(equation.rhs):
+            for rhs in self.find_symbols_and_derivatives([equation.rhs]):
                 # if the symbol maps to a node in the graph
                 if rhs in graph.nodes:
                     # add the dependency edge
@@ -695,17 +695,17 @@ class Model(object):
         return float(self.dummy_metadata[symbol].initial_value)
 
     def find_symbols_and_derivatives(self, expression):
-        """ Returns a set containing all symbols and derivatives referenced in an expression. """
+        """ Returns a set containing all symbols and derivatives referenced in a list of expressions.
+
+        :param expression: a list of expressions to get symbols for.
+        :return: a set of symbols and derivative objects.
+        """
         symbols = set()
-
-        # if this expression is a derivative or a dummy symbol which is not a number placeholder
-        if expression.is_Derivative or (expression.is_Dummy and not self.get_meta_dummy(expression).number):
-            symbols.add(expression)
-        # otherwise, descend into sub-expressions and collect symbols
-        else:
-            for arg in expression.args:
-                symbols |= self.find_symbols_and_derivatives(arg)
-
+        for expr in expression:
+            if expr.is_Derivative or (expr.is_Dummy and not self.get_meta_dummy(expr).number):
+                symbols.add(expr)
+            else:
+                symbols |= self.find_symbols_and_derivatives(expr.args)
         return symbols
 
     def find_variable(self, search_dict):

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -98,3 +98,35 @@ class TestModelAPI(object):
         rhs = model.add_number(number=sp.Float(12), units=str(v_unit))
         model.set_equation(lhs, rhs)
 
+    def test_find_symbols_and_derivatives(self, model):
+        """ Tests Model.find_symbols_and_derivatives. """
+
+        model.get_equation_graph()
+
+        # Test on single variable expressions
+        t = model.get_free_variable_symbol()
+        syms = model.find_symbols_and_derivatives([t])
+        assert len(syms) == 1
+        assert t in syms
+
+        v = model.get_symbol_by_ontology_term(OXMETA, "membrane_voltage")
+        dvdt = sp.Derivative(v, t)
+        syms = model.find_symbols_and_derivatives([dvdt])
+        assert len(syms) == 1
+        assert sp.Derivative(v, t) in syms
+
+        # Test on longer expressions
+        x = sp.Float(1) + t * sp.sqrt(dvdt) - t
+        syms = model.find_symbols_and_derivatives([x])
+        assert len(syms) == 2
+        assert t in syms
+        assert sp.Derivative(v, t) in syms
+
+        # Test on multiple expressions
+        y = sp.Float(2) + v
+        syms = model.find_symbols_and_derivatives([x, y])
+        assert len(syms) == 3
+        assert v in syms
+        assert t in syms
+        assert sp.Derivative(v, t) in syms
+


### PR DESCRIPTION
Is now public again, and accepts a sequence of expressions as input.
Added test.