### PR TITLE
Change Model.add_number signature

### DIFF
--- a/cellmlmanip/mathml2sympy/transpiler.py
+++ b/cellmlmanip/mathml2sympy/transpiler.py
@@ -140,7 +140,7 @@ class Transpiler(object):
                 if len(node.childNodes) == 3 and node.childNodes[1].tagName == 'sep':
                     mantissa = node.childNodes[0].data.strip()
                     exponent = int(node.childNodes[2].data.strip())
-                    number = sympy.Float('%se%d' % (mantissa, exponent))
+                    number = float('%se%d' % (mantissa, exponent))
                 else:
                     raise SyntaxError('Expecting '
                                       '<cn type="e-notation">significand<sep/>exponent</cn>.'
@@ -150,7 +150,6 @@ class Transpiler(object):
                                           + node.attributes['type'].value)
         else:
             number = float(node.childNodes[0].data.strip())
-            number = sympy.Number(number)
 
         if self.number_generator:
             return self.number_generator(number, node.attributes['cellml:units'].value)

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -91,12 +91,11 @@ class Model(object):
         """
         Creates and returns a :class:`NumberDummy` to represent a number with units in sympy expressions.
 
-        :param number: A ``sympy.Number``.
+        :param number: A number (anything convertible to float).
         :param units: A string unit representation.
 
-        :return: The ``sympy.Dummy`` object used to represent this number.
+        :return: A :class:`NumberDummy` object.
         """
-        assert isinstance(value, sympy.Number), 'The argument `value` must be a sympy.Number.'
         return NumberDummy(value, self.units.get_quantity(units))
 
     def add_variable(self, name, units, initial_value=None,
@@ -162,7 +161,7 @@ class Model(object):
                 factor = self.units.convert_to(1 * source.units, target.units).magnitude
 
                 # Dummy to represent this factor in equations, having units for conversion
-                factor_dummy = self.add_number(sympy.Float(factor), str(target.units / source.units))
+                factor_dummy = self.add_number(factor, str(target.units / source.units))
 
                 # Add an equations making the connection with the required conversion
                 self.equations.append(sympy.Eq(target, source.assigned_to * factor_dummy))
@@ -453,8 +452,7 @@ class Model(object):
                     # this variable is a parameter - add to graph and connect to lhs
                     rhs.type = 'parameter'
                     unit = rhs.units
-                    number = sympy.Float(rhs.initial_value)
-                    dummy = self.add_number(number, str(unit))
+                    dummy = self.add_number(rhs.initial_value, str(unit))
                     graph.add_node(rhs, equation=sympy.Eq(rhs, dummy), variable_type='parameter')
                     graph.add_edge(rhs, lhs)
 

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -96,7 +96,7 @@ class TestModelAPI(object):
         assert v.type == 'state'
 
         # Now clamp it to -80mV
-        rhs = model.add_number(sp.Number(-80), str(v.units))
+        rhs = model.add_number(-80, str(v.units))
         model.set_equation(v, rhs)
 
         # Check that V is no longer a state
@@ -114,7 +114,7 @@ class TestModelAPI(object):
             {'units': str(v.units)},
             {'units': str(t.units), 'exponent': -1},
         ])
-        rhs = model.add_number(sp.Number(0), dvdt_units)
+        rhs = model.add_number(0, dvdt_units)
         model.set_equation(lhs, rhs)
 
         # Check that V is a state again
@@ -123,6 +123,6 @@ class TestModelAPI(object):
 
         # Set equation for a newly created variable
         lhs = model.add_variable(name='an_incredibly_unlikely_variable_name', units=str(v.units))
-        rhs = model.add_number(sp.Float(12), str(v.units))
+        rhs = model.add_number(12, str(v.units))
         model.set_equation(lhs, rhs)
 


### PR DESCRIPTION
Model.add_number() now takes floats etc. as arguments, not (necessarily) sympy.Number objects. 

See #134.