### PR TITLE
added sort to get_derived_quantities

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -265,7 +265,7 @@ class Model(object):
         The list is ordered by appearance in the cellml document.
         """
         derivative_symbols = [v for v in self.graph if isinstance(v, sympy.Derivative)]
-        return sorted(derivative_symbols, key=lambda var: var.args[0].order_added)
+        return sorted(derivative_symbols, key=lambda state_var: state_var.args[0].order_added)
 
     def get_derived_quantities(self):
         """Returns a list of derived quantities found in the given model graph.
@@ -274,7 +274,7 @@ class Model(object):
         derived_quantities = [v for v, node in self.graph.nodes.items()
                               if not isinstance(v, sympy.Derivative)
                               and node.get('variable_type', '') not in ('state', 'free', 'parameter')]
-        return sorted(derived_quantities, key=lambda state_var: state_var.order_added)
+        return sorted(derived_quantities, key=lambda var: var.order_added)
 
     def get_state_symbols(self):
         """Returns a list of state variables found in the given model graph.

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -265,7 +265,7 @@ class Model(object):
         The list is ordered by appearance in the cellml document.
         """
         derivative_symbols = [v for v in self.graph if isinstance(v, sympy.Derivative)]
-        return sorted(derivative_symbols, key=lambda state_var: state_var.args[0].order_added)
+        return sorted(derivative_symbols, key=lambda var: var.args[0].order_added)
 
     def get_derived_quantities(self):
         """Returns a list of derived quantities found in the given model graph.

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -271,9 +271,10 @@ class Model(object):
         """Returns a list of derived quantities found in the given model graph.
         A derived quantity is any variable that is not a state variable or parameter/constant.
         """
-        return [v for v, node in self.graph.nodes.items()
-                if not isinstance(v, sympy.Derivative)
-                and node.get('variable_type', '') not in ('state', 'free', 'parameter')]
+        derived_quantities = [v for v, node in self.graph.nodes.items()
+                              if not isinstance(v, sympy.Derivative)
+                              and node.get('variable_type', '') not in ('state', 'free', 'parameter')]
+        return sorted(derived_quantities, key=lambda state_var: state_var.order_added)
 
     def get_state_symbols(self):
         """Returns a list of state variables found in the given model graph.

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -69,11 +69,11 @@ class TestModelFunctions():
         assert len(derived_quantities) == 0
 
         derived_quantities = simple_ode_model.get_derived_quantities()
-        assert str(sorted(derived_quantities, key=str)) == \
-            '[_circle_sibling$local_complex_maths, _circle_x_sibling$x2, _circle_y_implementation$rhs, '\
-            '_deriv_on_rhs$sv1_rate, _deriv_on_rhs1a$sv1_rate, _deriv_on_rhs1b$sv1_rate, _deriv_on_rhs2a$sv1_rate, '\
-            '_deriv_on_rhs2b$sv1_rate, _derived_from_state_var$dbl_sv1, _single_ode_rhs_computed_var$a, '\
-            '_time_units_conversion1$time, _time_units_conversion2$time]'
+        assert str(derived_quantities) == \
+            '[_single_ode_rhs_computed_var$a, _derived_from_state_var$dbl_sv1, _deriv_on_rhs$sv1_rate, '\
+            '_circle_x_sibling$x2, _circle_y_implementation$rhs, _circle_sibling$local_complex_maths, '\
+            '_time_units_conversion1$time, _deriv_on_rhs1a$sv1_rate, _time_units_conversion2$time, '\
+            '_deriv_on_rhs2a$sv1_rate, _deriv_on_rhs1b$sv1_rate, _deriv_on_rhs2b$sv1_rate]'
 
     def test_get_state_symbols(self, basic_model):
         """ Tests Model.get_state_symbols() works correctly. """


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This adds sorting in document order to get_derived_quantities

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Other api methods also return symbols in document order, which is useful for generating predictable (i.e. always the same) code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

