### PR TITLE
simplied get_ontology_terms_by_symbol to use symbol.cmeta_id

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -404,13 +404,12 @@ class Model(object):
         if symbol.cmeta_id:
             predicate = ('http://biomodels.net/biology-qualifiers/', 'is')
             predicate = create_rdf_node(predicate)
-            for delimeter in ('#', '/'):  # Look for terms using either possible namespace delimiter
-                subject = rdflib.term.URIRef(delimeter + symbol.cmeta_id)
-                for object in self.rdf.objects(subject, predicate):
-                    # We are only interested in annotation within the namespace
-                    if namespace_uri is None or str(object).startswith(namespace_uri):
-                        uri_parts = str(object).split(delimeter)
-                        ontology_terms.append(uri_parts[-1])
+            subject = rdflib.term.URIRef('#' + symbol.cmeta_id)
+            for object in self.rdf.objects(subject, predicate):
+                # We are only interested in annotation within the namespace
+                if namespace_uri is None or str(object).startswith(namespace_uri):
+                    uri_parts = str(object).split('#')
+                    ontology_terms.append(uri_parts[-1])
         return ontology_terms
 
     def get_units(self, name):

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -401,12 +401,11 @@ class Model(object):
         Will return a list of term names.
         """
         ontology_terms = []
-        cmeta_id = self.graph.nodes[symbol].get('cmeta_id', None)
-        if cmeta_id:
+        if symbol.cmeta_id:
             predicate = ('http://biomodels.net/biology-qualifiers/', 'is')
             predicate = create_rdf_node(predicate)
             for delimeter in ('#', '/'):  # Look for terms using either possible namespace delimiter
-                subject = rdflib.term.URIRef(delimeter + cmeta_id)
+                subject = rdflib.term.URIRef(delimeter + symbol.cmeta_id)
                 for object in self.rdf.objects(subject, predicate):
                     # We are only interested in annotation within the namespace
                     if namespace_uri is None or str(object).startswith(namespace_uri):

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -114,6 +114,11 @@ def test_get_ontology_terms_by_symbol2(hh_model):
     assert len(annotation) == 1
     assert annotation[0] == "membrane_voltage"
 
+    # Get a symbol without cmeta_id and check that get_ontology_terms_by_symbol works
+    symbol = [s for s in hh_model.get_state_symbols() if not s.cmeta_id][0]
+    annotation = hh_model.get_ontology_terms_by_symbol(symbol)
+    assert len(annotation) == 0
+
 
 def test_has_ontology_term_by_symbol(bad_annotation_model):
     """ Tests Model.has_ontology_annotation() function when the annotation is not correct. """


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
in `get_ontology_terms_by_symbol` it now checks and uses `symbol.cmeta_id` instead of `self.graph.nodes[symbol].get('cmeta_id', None)`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
This is simpler and it prevents issues with variables that are not in the graph (e.g. because they aren't involved in any equations)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.
No comments changed

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

