### PR TITLE
Conversion same units different name

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -689,7 +689,7 @@ class Model(object):
 
         original_units = original_variable.units
         # no conversion necessary
-        if self.units.get_conversion_factor(units, from_unit=original_units) == 1.0:
+        if  1 * original_units == 1 * units:
             return original_variable
 
         # conversion_factor for old units to new

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -689,7 +689,7 @@ class Model(object):
 
         original_units = original_variable.units
         # no conversion necessary
-        if  1 * original_units == 1 * units:
+        if 1 * original_units == 1 * units:
             return original_variable
 
         # conversion_factor for old units to new

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -624,7 +624,7 @@ class Model(object):
         """ Returns an iterator over this model's variable symbols. """
         return self._name_to_symbol.values()
 
-    def convert_variable(self, original_variable, units, direction, raise_errors=True):
+    def convert_variable(self, original_variable, units, direction):
         """
         Add a new linked version of the given variable in the desired units.
 
@@ -679,19 +679,13 @@ class Model(object):
                           equations will be adjusted
                           or DataDirectionFlow.OUTPUT; the variable to be changed is an output, equations
                           are unaffected apart from converting the actual output
-        :param raise_errors: determines whether the method will throw an error if one of the checks fails
-                          if raise_errors==False and checks fail, the original variable is returned unchanged
         :return: new variable with desired units, or original unchanged if conversion was not necessary
         :throws: AssertionError if the arguments are of incorrect type
                                 or the variable does not exist in the model
                 DimensionalityError if the unit conversion is impossible
         """
         # assertion errors will be thrown here if arguments are incorrect type
-        checks_passed = self._check_arguments_for_convert_variables(original_variable, units, direction, raise_errors)
-
-        # no conversion possible (checks failed)
-        if not checks_passed:
-            return original_variable
+        self._check_arguments_for_convert_variables(original_variable, units, direction)
 
         original_units = original_variable.units
         # no conversion necessary
@@ -733,41 +727,26 @@ class Model(object):
 
         return new_variable
 
-    def _check_arguments_for_convert_variables(self, variable, units, direction, raise_errors=True):
+    def _check_arguments_for_convert_variables(self, variable, units, direction):
         """
         Checks the arguments of the convert_variable function.
         :param variable: variable must be a VariableDummy object present in the model
         :param units: units must be a pint Unit object in this model
         :param direction: must be part of DataDirectionFlow enum
-        :param raise_errors: determines whether the method will throw an error if one of the checks fails
-        :throws: AssertionError if raise_errors and (the arguments are of incorrect type
-                                or the variable does not exist in the model)
-        :return: returns whether all checks have passed successfully.
+        :throws: AssertionError if the arguments are of incorrect type
+                                or the variable does not exist in the model
        """
         # variable should be a VariableDummy
-        is_VariableDummy = isinstance(variable, VariableDummy)
+        assert isinstance(variable, VariableDummy)
 
         # variable must be in model
-        is_in_model = getattr(variable, 'name', '') in self._name_to_symbol
+        assert variable.name in self._name_to_symbol
 
         # units should be a pint Unit object in the registry for this model
-        units_in_registry = isinstance(units, self.units.ureg.Unit)
-
-        # Check unit dimensionality
-        demensionality_ok = \
-            units_in_registry and is_VariableDummy and variable.units.dimensionality == units.dimensionality
+        assert isinstance(units, self.units.ureg.Unit)
 
         # direction should be part of enum
-        direction_in_enum = isinstance(direction, DataDirectionFlow)
-
-        if raise_errors:
-            assert is_VariableDummy
-            assert is_in_model
-            assert units_in_registry
-            assert demensionality_ok
-            assert direction_in_enum
-
-        return is_VariableDummy and is_in_model and units_in_registry and demensionality_ok and direction_in_enum
+        assert isinstance(direction, DataDirectionFlow)
 
     def _replace_derivatives(self, new_derivative):
         """

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -982,4 +982,3 @@ class VariableDummy(sympy.Dummy):
 
     def __str__(self):
         return self.name
-

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -744,7 +744,7 @@ class Model(object):
         is_VariableDummy = isinstance(variable, VariableDummy)
 
         # variable must be in model
-        is_in_model = variable.getattr('name', '') in self._name_to_symbol
+        is_in_model = getattr(variable, 'name', '') in self._name_to_symbol
 
         # units should be a pint Unit object in the registry for this model
         units_in_registry = isinstance(units, self.units.ureg.Unit)

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -740,8 +740,6 @@ class Model(object):
                                 or the variable does not exist in the model)
         :return: returns whether all checks have passed successfully.
        """
-        arguments_ok = True
-
         # variable should be a VariableDummy
         is_VariableDummy = isinstance(variable, VariableDummy)
 
@@ -759,7 +757,7 @@ class Model(object):
             assert is_in_model
             assert units_in_registry
             assert direction_in_enum
-        
+
         return is_VariableDummy and is_in_model and units_in_registry and direction_in_enum
 
     def _replace_derivatives(self, new_derivative):

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -982,3 +982,4 @@ class VariableDummy(sympy.Dummy):
 
     def __str__(self):
         return self.name
+

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -744,7 +744,7 @@ class Model(object):
         is_VariableDummy = isinstance(variable, VariableDummy)
 
         # variable must be in model
-        is_in_model = variable.name in self._name_to_symbol
+        is_in_model = variable.getattr('name', '') in self._name_to_symbol
 
         # units should be a pint Unit object in the registry for this model
         units_in_registry = isinstance(units, self.units.ureg.Unit)

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -14,11 +14,11 @@ class TestUnitConversion:
     def local_model(scope='function'):
         """ Fixture to load a local copy of  the basic_ode model that may get modified. """
         return shared.load_model('basic_ode')
-        
+
     @pytest.fixture
     def br_model(scope='function'):
         """ Fixture to load a local copy of  the basic_ode model that may get modified. """
-        return shared.load_model('beeler_reuter_model_1977')        
+        return shared.load_model('beeler_reuter_model_1977')
 
     @pytest.fixture
     def literals_model(scope='function'):
@@ -740,8 +740,10 @@ class TestUnitConversion:
     def test_convert_same_unit_different_name(self, br_model):
         """ Tests the Model.convert_variable() function when conversion to current unit under a different name.
         """
-        br_model.units.add_custom_unit('millimolar', [{'units': 'mole', 'prefix': 'milli'}, {'units': 'litre', 'exponent': '-1'}])
-        unit = br_model.get_units('concentration_units') #  [{'units': 'mole', 'prefix': 'nano'}, {'units': 'litre', 'exponent': '-3', prefix: 'milli'}])       
+        br_model.units.add_custom_unit('millimolar', [{'units': 'mole', 'prefix': 'milli'},
+                                       {'units': 'litre', 'exponent': '-1'}])
+        # [{'units': 'mole', 'prefix': 'nano'}, {'units': 'litre', 'exponent': '-3', prefix: 'milli'}])
+        unit = br_model.get_units('concentration_units')
         variable = br_model.get_symbol_by_ontology_term(shared.OXMETA, "cytosolic_calcium_concentration")
         direction = DataDirectionFlow.INPUT
         assert br_model.convert_variable(variable, unit, direction) == variable

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -711,26 +711,33 @@ class TestUnitConversion:
         # arguments wrong types
         with pytest.raises(AssertionError):
             local_model.convert_variable('x', unit, direction)
+        local_model.convert_variable('x', unit, direction, raise_errors=False) == 'x'
 
         with pytest.raises(AssertionError):
             local_model.convert_variable(variable, 'x', direction)
+        local_model.convert_variable(variable, 'x', direction, raise_errors=False) == variable
 
         with pytest.raises(AssertionError):
             local_model.convert_variable(variable, unit, 'x')
+        local_model.convert_variable(variable, unit, 'x', raise_errors=False) == variable
+            
 
         # variable not present in model
         model = shared.load_model('literals_for_conversion_tests')
         other_var = model.get_symbol_by_name('env_ode$x')
         with pytest.raises(AssertionError):
             local_model.convert_variable(other_var, unit, direction)
+        local_model.convert_variable(other_var, unit, direction, raise_errors=False) == other_var
 
         # ontology term not present in model
         with pytest.raises(AssertionError):
             local_model.convert_variable('current', unit, direction)
+        local_model.convert_variable('current', unit, direction, raise_errors=False) == 'current'
 
         # unit conversion is impossible
         with pytest.raises(DimensionalityError):
             local_model.convert_variable(variable, bad_unit, direction)
+        local_model.convert_variable(variable, bad_unit, direction, raise_errors=False) == variable
 
     def test_unique_names(self, silly_names):
         # original state

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -1,5 +1,4 @@
 import pytest
-from pint import DimensionalityError
 
 from cellmlmanip import units
 from cellmlmanip.model import DataDirectionFlow
@@ -720,7 +719,6 @@ class TestUnitConversion:
         with pytest.raises(AssertionError):
             local_model.convert_variable(variable, unit, 'x')
         local_model.convert_variable(variable, unit, 'x', raise_errors=False) == variable
-            
 
         # variable not present in model
         model = shared.load_model('literals_for_conversion_tests')
@@ -735,7 +733,7 @@ class TestUnitConversion:
         local_model.convert_variable('current', unit, direction, raise_errors=False) == 'current'
 
         # unit conversion is impossible
-        with pytest.raises(DimensionalityError):
+        with pytest.raises(AssertionError):
             local_model.convert_variable(variable, bad_unit, direction)
         local_model.convert_variable(variable, bad_unit, direction, raise_errors=False) == variable
 

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -14,6 +14,11 @@ class TestUnitConversion:
     def local_model(scope='function'):
         """ Fixture to load a local copy of  the basic_ode model that may get modified. """
         return shared.load_model('basic_ode')
+        
+    @pytest.fixture
+    def br_model(scope='function'):
+        """ Fixture to load a local copy of  the basic_ode model that may get modified. """
+        return shared.load_model('beeler_reuter_model_1977')        
 
     @pytest.fixture
     def literals_model(scope='function'):
@@ -732,14 +737,14 @@ class TestUnitConversion:
         with pytest.raises(DimensionalityError):
             local_model.convert_variable(variable, bad_unit, direction)
 
-    def test_convert_same_unit_different_name(self, local_model):
+    def test_convert_same_unit_different_name(self, br_model):
         """ Tests the Model.convert_variable() function when conversion to current unit under a different name.
         """
-        local_model.units.add_custom_unit('millisecond', [{'prefix': 'milli', 'units': 'second'}])
-        unit = local_model.get_units('millisecond')
-        variable = local_model.get_free_variable_symbol()
+        br_model.units.add_custom_unit('millimolar', [{'units': 'mole', 'prefix': 'milli'}, {'units': 'litre', 'exponent': '-1'}])
+        unit = br_model.get_units('concentration_units') #  [{'units': 'mole', 'prefix': 'nano'}, {'units': 'litre', 'exponent': '-3', prefix: 'milli'}])       
+        variable = br_model.get_symbol_by_ontology_term(shared.OXMETA, "cytosolic_calcium_concentration")
         direction = DataDirectionFlow.INPUT
-        assert local_model.convert_variable(variable, unit, direction) == variable
+        assert br_model.convert_variable(variable, unit, direction) == variable
 
     def test_unique_names(self, silly_names):
         # original state


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
uses conversion_factor==1.0 to determine if units are the same.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
fixes #197  units that are the same except their string name will get seen as the same (and not converted)

I also added an optional flag to not get errors thrown if a unit conversion isn't possible. In that case it just returns the original variable. the reason is that I have quite a few cases where I want to try and convert but it may not always be possible (e.g. sometimes calcium_concentration has the units dimensionless). Personally i find it easier if I don't need to write elaborate checks but that's open for discussion I suppose.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

