### PR TITLE
removed add_preferred_custom_unit_name

### DIFF
--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -204,28 +204,6 @@ class UnitStore(object):
 
             self._define_pint_unit(units_name, unit_definition)
 
-    def add_preferred_custom_unit_name(self, units_name, unit_attributes):
-        """
-        Set a prefered name for all equivalent custom units.
-
-        If the unit does not exist yet, also define a new Pint unit definition to the unit registry.
-        PLEASE NOTE: not retrospective, assumes you are not adding new expressions to the model.
-        It also does not do any unit conversions, only works on equivalent units with different names.
-        :param units_name: the prefered name for this unit and all units in the model that are equivalent
-        :param unit_attributes: dict object for unit
-            {'multiplier': float, 'units': string, 'exponent': integer, 'prefix': string/integer}
-            Not all fields necessary but 'units' must match a unit in Pint registry
-        """
-        try:
-            self.add_custom_unit(units_name, unit_attributes)
-        except AssertionError:
-            pass  # Unit already exists, but that is not a problem
-
-        unit = getattr(self.ureg, units_name)
-        for variable in self.model.variables():
-            if self.is_unit_equal(variable.units, unit):
-                variable.units = unit
-
     def add_base_unit(self, units_name):
         """Define a new base unit in the Pint registry.
         :param units_name: string name of unit to add

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -165,18 +165,6 @@ class TestUnits(object):
         assert(quantity_store._make_pint_unit_definition('kg_mm_per_ms', unit_attributes) ==
                'kg_mm_per_ms=(meter * 1e-3)*(((second * 0.001))**-1)*(2 * kilogram)')
 
-    def test_add_preferred_custom_unit_name(self, simple_ode_model):
-        """ Tests Units.add_preferred_custom_unit_name() function. """
-        time_var = simple_ode_model.get_symbol_by_ontology_term(shared.OXMETA, "time")
-        assert str(simple_ode_model.units.summarise_units(time_var)) == "ms"
-        simple_ode_model.units.add_preferred_custom_unit_name('millisecond', [{'prefix': 'milli', 'units': 'second'}])
-        assert str(simple_ode_model.units.summarise_units(time_var)) == "millisecond"
-        # add_custom_unit does not allow adding already existing units but add_preferred_custom_unit_name does since we
-        # cannot know in advance if a model will already have the unit named this way. To test this we add the same unit
-        # again
-        simple_ode_model.units.add_preferred_custom_unit_name('millisecond', [{'prefix': 'milli', 'units': 'second'}])
-        assert str(simple_ode_model.units.summarise_units(time_var)) == "millisecond"
-
     # Test UnitCalculator class
 
     def test_unit_calculator(self, quantity_store):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This removes the `model.units._add_preferred_custom_unit_name functionality`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
I originally added this functionality to deal with units that were the same but had a different name. It is quite slow, potentially confusing for users and we now have better ways to recognize them (as used in `model.convert_variable`). Neither myself not the rest of weblab use it anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
(feature removal)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.
no documentation to update

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

