### PR TITLE
fixed bug with conversion derivatives

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -754,7 +754,7 @@ class Model(object):
         :param new_derivative: new variable representing the derivative
         """
         for equation in self.equations:
-            for argument in equation.atoms(sympy.Derivative):
+            for argument in equation.rhs.atoms(sympy.Derivative):
                 if new_derivative['expression'] == argument:
                     # add new equation
                     new_eqn = equation.subs(new_derivative['expression'], new_derivative['variable'])

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -754,7 +754,7 @@ class Model(object):
         :param new_derivative: new variable representing the derivative
         """
         for equation in self.equations:
-            for argument in equation.rhs.args:
+            for argument in equation.atoms(sympy.Derivative):
                 if new_derivative['expression'] == argument:
                     # add new equation
                     new_eqn = equation.subs(new_derivative['expression'], new_derivative['variable'])

--- a/tests/cellml_files/repeated_ode_for_conversion_tests.cellml
+++ b/tests/cellml_files/repeated_ode_for_conversion_tests.cellml
@@ -50,15 +50,19 @@
                 <eq/>
                 <ci>x</ci>
                 <apply>
-                    <times/>
+                    <plus/>
+                    <cn cellml:units="mV_per_ms">1</cn>
                     <apply>
-                        <diff/>
-                        <bvar>
-                            <ci>time</ci>
-                        </bvar>
-                        <ci>sv1</ci>
+                        <times/>
+                        <apply>
+                            <diff/>
+                            <bvar>
+                                <ci>time</ci>
+                            </bvar>
+                            <ci>sv1</ci>
+                        </apply>
+                        <cn cellml:units="mV_per_ms">3</cn>
                     </apply>
-                    <cn cellml:units="mV_per_ms">3</cn>
                 </apply>
             </apply>
             <apply>

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -738,8 +738,7 @@ class TestUnitConversion:
             local_model.convert_variable(variable, bad_unit, direction)
 
     def test_convert_same_unit_different_name(self, br_model):
-        """ Tests the Model.convert_variable() function when conversion to current unit under a different name.
-        """
+        """ Tests the Model.convert_variable() function when conversion to current unit under a different name."""
         br_model.units.add_custom_unit('millimolar', [{'units': 'mole', 'prefix': 'milli'},
                                        {'units': 'litre', 'exponent': '-1'}])
         # [{'units': 'mole', 'prefix': 'nano'}, {'units': 'litre', 'exponent': '-3', prefix: 'milli'}])
@@ -747,6 +746,25 @@ class TestUnitConversion:
         variable = br_model.get_symbol_by_ontology_term(shared.OXMETA, "cytosolic_calcium_concentration")
         direction = DataDirectionFlow.INPUT
         assert br_model.convert_variable(variable, unit, direction) == variable
+
+    def test_convert_state_symbols(self, aslanidi_model):
+        """ Tests if get_state_symbols still works (and the graph is rebuilt properly)
+        after after conversion of the time (s to ms).
+
+        The aslanidi_model has derivatives on the rhs of equations that aren't at the top level being replaced.
+        """
+        model = aslanidi_model
+        old_state_symbols = model.get_state_symbols()
+        assert len(old_state_symbols) == 29
+
+        model.units.add_custom_unit('millisecond', [{'prefix': 'milli', 'units': 'second'}])
+        time_variable = model.get_free_variable_symbol()
+        desired_units = model.units.ureg.millisecond
+
+        model.convert_variable(time_variable, desired_units, DataDirectionFlow.INPUT)
+        state_symbols = model.get_state_symbols()
+        assert len(state_symbols) == 29
+        assert old_state_symbols == state_symbols
 
     def test_unique_names(self, silly_names):
         # original state


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
There was a bug where after converting a variable involved in derivatives (e.g. time) the graph couldn't be rebuilt. I changed `_replace_derivatives` to use `for argument in equation.atoms(sympy.Derivative)` instead of `for argument in equation.args` as this successfully recurses to find the derivatives

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
fixes #199 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

