### PR TITLE
Refactor initial_value / parameter handling

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -639,14 +639,17 @@ class Model(object):
         """ Returns the evaluated value of the given symbol's RHS. """
         return float(self.graph.nodes[symbol]['equation'].rhs.evalf())
 
-    def find_symbols_and_derivatives(self, expression):
+    def find_symbols_and_derivatives(self, expressions):
         """ Returns a set containing all symbols and derivatives referenced in a list of expressions.
 
-        :param expression: a list of expressions to get symbols for.
+        Note that we can't just use ``.atoms(VariableDummy, sympy.Derivative)`` for this, because it
+        will return the state and free variables from inside derivatives, which is not what we want.
+
+        :param expressions: an iterable of expressions to get symbols for.
         :return: a set of symbols and derivative objects.
         """
         symbols = set()
-        for expr in expression:
+        for expr in expressions:
             if expr.is_Derivative or isinstance(expr, VariableDummy):
                 symbols.add(expr)
             else:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -769,7 +769,8 @@ class Model(object):
         # if free variable
         if original_variable == free_symbol:
             # for each derivative wrt to free variable add necessary variables/equations
-            for ode in list(self._ode_definition_map.values()):
+            for ode in [eq for v, eq in sorted(self._ode_definition_map.items(),
+                                               key=lambda v_eq: v_eq[0].order_added)]:
                 if ode.args[0].args[1].args[0] == original_variable:
                     new_derivatives.append(self._convert_free_variable_deriv(ode, new_variable, cf))
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -553,14 +553,11 @@ class Model(object):
                 if state_symbol not in graph.nodes:
                     graph.add_node(state_symbol, equation=None, variable_type=state_symbol.type)
 
-        # Add more meta-data to the graph
+        # Store variable type in the graph too
         for variable in graph.nodes:
             if not variable.is_Derivative:
-                for key in ['cmeta_id', 'name', 'units']:
-                    if getattr(variable, key):
-                        graph.nodes[variable][key] = getattr(variable, key)
-                if variable.type is not None:
-                    graph.nodes[variable]['variable_type'] = variable.type
+                assert variable.type is not None
+                graph.nodes[variable]['variable_type'] = variable.type
 
         # Cache graph and return
         self._graph = graph

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -510,12 +510,8 @@ class Model(object):
         for equation in self.equations:
             equation_count += 1
 
-            # Determine LHS.
-            lhs = equation.lhs
-            if not (lhs.is_Derivative or isinstance(lhs, VariableDummy)):
-                raise RuntimeError('DAEs are not supported. All equations must be of form `x = ...` or `dx/dt = ...')
-
             # Add the lhs symbol of the equation to the graph
+            lhs = equation.lhs
             graph.add_node(lhs, equation=equation)
 
             # Update variable meta data based on the variable's role in the model
@@ -553,7 +549,7 @@ class Model(object):
                     graph.add_node(rhs, equation=None, variable_type=rhs.type)
                     graph.add_edge(rhs, lhs)
                 else:
-                    assert False, 'Unexpected symbol {} on RHS'.format(rhs)
+                    assert False, 'Unexpected symbol {} on RHS'.format(rhs)  # pragma: no cover
 
             # check that the free  and state variables are defined as a node
             if lhs.is_Derivative:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -563,8 +563,6 @@ class Model(object):
                 for key in ['cmeta_id', 'name', 'units']:
                     if getattr(variable, key):
                         graph.nodes[variable][key] = getattr(variable, key)
-                if variable.type == 'state' and variable.initial_value is not None:
-                    graph.nodes[variable]['initial_value'] = sympy.Float(variable.initial_value)
                 if variable.type is not None:
                     graph.nodes[variable]['variable_type'] = variable.type
 
@@ -640,15 +638,6 @@ class Model(object):
     def get_value(self, symbol):
         """ Returns the evaluated value of the given symbol's RHS. """
         return float(self.graph.nodes[symbol]['equation'].rhs.evalf())
-
-    def get_initial_value(self, symbol):
-        """
-        Returns the initial value of the given symbol.
-
-        :param symbol: Sympy Dummy object of required symbol
-        :return: float of initial value
-        """
-        return symbol.initial_value
 
     def find_symbols_and_derivatives(self, expression):
         """ Returns a set containing all symbols and derivatives referenced in a list of expressions.

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -120,10 +120,12 @@ class Model(object):
         :param var: the VariableDummy, either a state var or normal var
         :param equation: the new definition being added
         """
-        assert var not in self._ode_definition_map, 'The variable {} is defined twice ({} and {})'.format(
-            var, equation, self._ode_definition_map[var])
-        assert var not in self._var_definition_map, 'The variable {} is defined twice ({} and {})'.format(
-            var, equation, self._var_definition_map[var])
+        if var in self._ode_definition_map:
+            raise ValueError('The variable {} is defined twice ({} and {})'.format(
+                var, equation, self._ode_definition_map[var]))
+        if var in self._var_definition_map:
+            raise ValueError('The variable {} is defined twice ({} and {})'.format(
+                var, equation, self._var_definition_map[var]))
 
     def add_number(self, value, units):
         """
@@ -224,8 +226,9 @@ class Model(object):
             raise ValueError('Target already assigned to %s before assignment to %s' %
                              (target.assigned_to, source.assigned_to))
 
-        assert target not in self._var_definition_map, 'Multiple definitions for {} ({} and {})'.format(
-            target, source, self._var_definition_map[target])
+        if target in self._var_definition_map:
+            raise ValueError('Multiple definitions for {} ({} and {})'.format(
+                target, source, self._var_definition_map[target]))
 
         # If source/target variable is in the same unit
         if source.units == target.units:
@@ -351,7 +354,7 @@ class Model(object):
         """Returns a list of state variables found in the given model graph.
         The list is ordered by appearance in the cellml document.
         """
-        state_symbols = [v for v in self._ode_definition_map.keys()]
+        state_symbols = list(self._ode_definition_map.keys())
         return sorted(state_symbols, key=lambda state_var: state_var.order_added)
 
     def get_free_variable_symbol(self):

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -101,6 +101,9 @@ class Parser(object):
         self._add_relationships(model_xml)
         self._add_connection(model_xml)
 
+        # Canonicalise representation
+        self.model.transform_constants()
+
         return self.model
 
     @staticmethod

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -342,10 +342,6 @@ class Parser(object):
         # those variables we know are source variables
         connections_to_process = deque(connect_from_to)
 
-        # For testing: shuffle the order of connections TODO: REMOVE!
-        from random import shuffle
-        shuffle(connections_to_process)
-
         # keep processing the list of connections until we've done them all
         unchanged_loop_count = 0
         while connections_to_process:

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -50,14 +50,9 @@ class TestModelFunctions():
 
     def test_graph_for_dae(self):
         """ Checks if writing a DAE in a model raises an exceptions. """
-
-        # Parsing should be OK
         path = os.path.join(os.path.dirname(__file__), 'cellml_files', '4.algebraic_ode_model.cellml')
-        model = parser.Parser(path).parse()
-
-        # But equation graph will raise error (if accessed)
-        with pytest.raises(RuntimeError, match='DAEs are not supported'):
-            model.graph
+        with pytest.raises(ValueError, match='Equation LHS should be a derivative or variable'):
+            model = parser.Parser(path).parse()
 
     #######################################################################
     # this section contains tests for each get_XXX function on Model

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -52,7 +52,7 @@ class TestModelFunctions():
         """ Checks if writing a DAE in a model raises an exceptions. """
         path = os.path.join(os.path.dirname(__file__), 'cellml_files', '4.algebraic_ode_model.cellml')
         with pytest.raises(ValueError, match='Equation LHS should be a derivative or variable'):
-            model = parser.Parser(path).parse()
+            parser.Parser(path).parse()
 
     #######################################################################
     # this section contains tests for each get_XXX function on Model

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -110,13 +110,6 @@ class TestModelFunctions():
         free_variable_symbol = aslanidi_model.get_free_variable_symbol()
         assert free_variable_symbol.name == 'environment$time'
 
-    # also tested in test_aslanidi
-    def test_get_initial_value(self, aslanidi_model):
-        """ Tests Model.get_initial_value() works correctly. """
-
-        membrane_voltage = aslanidi_model.get_symbol_by_ontology_term(shared.OXMETA, "membrane_voltage")
-        assert(aslanidi_model.get_initial_value(membrane_voltage) == -80.0)
-
     def test_get_derivative_symbols(self, basic_model):
         """ Tests Model.get_derivative_symbols() works correctly. """
 

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -364,14 +364,21 @@ class TestModelFunctions():
         with pytest.raises(ValueError, match='The variable newvar is defined twice'):
             # Redefining normal var
             model.add_equation(sp.Eq(symbol, 3.0))
+
+        sv1 = model.get_symbol_by_cmeta_id('sv11')
         with pytest.raises(ValueError, match='The variable env_ode\\$sv1 is defined twice'):
             # Redefining state var
-            sv1 = model.get_symbol_by_cmeta_id('sv11')
             model.add_equation(sp.Eq(sv1, 2.0))
+
+        sv1_def = model._ode_definition_map[sv1]
+        with pytest.raises(ValueError, match='The variable env_ode\\$sv1 is defined twice'):
+            # Redefining with ODE
+            model.add_equation(sp.Eq(sv1_def.lhs, 1.0))
 
         # But if we don't check for duplicates these are 'OK'
         model.add_equation(sp.Eq(symbol, 3.0), check_duplicates=False)
         model.add_equation(sp.Eq(sv1, 2.0), check_duplicates=False)
+        model.add_equation(sp.Eq(sv1_def.lhs, 1.0), check_duplicates=False)
 
     def test_remove_equation(self, local_hh_model):
         """ Tests the Model.remove_equation method. """

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -369,6 +369,10 @@ class TestModelFunctions():
             sv1 = model.get_symbol_by_cmeta_id('sv11')
             model.add_equation(sp.Eq(sv1, 2.0))
 
+        # But if we don't check for duplicates these are 'OK'
+        model.add_equation(sp.Eq(symbol, 3.0), check_duplicates=False)
+        model.add_equation(sp.Eq(sv1, 2.0), check_duplicates=False)
+
     def test_remove_equation(self, local_hh_model):
         """ Tests the Model.remove_equation method. """
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -44,8 +44,8 @@ class TestParser(object):
 
     def test_equations_count(self, simple_ode_model):
         """Tests correct number of equations read and then created where necessary by parser. """
-        # Include 19 equations from model + 2 equations added by parser for unit conversion
-        assert len(simple_ode_model.equations) == 21  # NOTE: determined by eye!
+        # Include 19 equations from model + 2 equations added by parser for unit conversion + 1 constant
+        assert len(simple_ode_model.equations) == 22  # NOTE: determined by eye!
 
     def test_rdf(self, simple_ode_model):
         """ Tests correct number of rdf statements parsed. """

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -123,7 +123,7 @@ class TestUnitConversion:
         assert len(local_model.variables()) == 3
         symbol_a = local_model.get_symbol_by_cmeta_id('sv11')
         symbol_t = local_model.get_symbol_by_cmeta_id('time')
-        assert local_model.get_initial_value(symbol_a) == 2.0
+        assert symbol_a.initial_value == 2.0
         assert symbol_a.units == 'mV'
         assert symbol_t.units == 'ms'
         assert len(local_model.equations) == 1
@@ -141,10 +141,10 @@ class TestUnitConversion:
         symbol_x = literals_model.get_symbol_by_cmeta_id('current')
         symbol_y = literals_model.get_symbol_by_name('env_ode$y')
         assert symbol_x.name == 'env_ode$x'
-        assert literals_model.get_initial_value(symbol_a) == 2.0
-        assert not literals_model.get_initial_value(symbol_t)
-        assert not literals_model.get_initial_value(symbol_x)
-        assert not literals_model.get_initial_value(symbol_y)
+        assert symbol_a.initial_value == 2.0
+        assert symbol_t.initial_value is None
+        assert symbol_x.initial_value is None
+        assert symbol_y.initial_value is None
         assert symbol_a.units == 'mV'
         assert symbol_t.units == 'ms'
         assert symbol_x.units == 'pA'
@@ -160,7 +160,7 @@ class TestUnitConversion:
         assert len(multiode_model.variables()) == 5
         symbol_a = multiode_model.get_symbol_by_cmeta_id('sv11')
         symbol_t = multiode_model.get_symbol_by_cmeta_id('time')
-        assert multiode_model.get_initial_value(symbol_a) == 2.0
+        assert symbol_a.initial_value == 2.0
         assert symbol_a.units == 'mV'
         assert symbol_t.units == 'ms'
         assert len(multiode_model.equations) == 3
@@ -176,8 +176,8 @@ class TestUnitConversion:
         symbol_a = multiode_freevar_model.get_symbol_by_cmeta_id('sv11')
         symbol_t = multiode_freevar_model.get_symbol_by_cmeta_id('time')
         symbol_y = multiode_freevar_model.get_symbol_by_name('env_ode$y')
-        assert multiode_freevar_model.get_initial_value(symbol_a) == 2.0
-        assert multiode_freevar_model.get_initial_value(symbol_y) == 3.0
+        assert symbol_a.initial_value == 2.0
+        assert symbol_y.initial_value == 3.0
         assert symbol_a.units == 'mV'
         assert symbol_t.units == 'ms'
         assert symbol_y.units == 'mV'
@@ -225,17 +225,17 @@ class TestUnitConversion:
         assert newvar != original_var
         assert len(local_model.variables()) == 5
         symbol_a = local_model.get_symbol_by_cmeta_id('sv11')
-        assert local_model.get_initial_value(symbol_a) == 0.002
+        assert symbol_a.initial_value == 0.002
         assert symbol_a.units == 'volt'
         assert symbol_a.name == 'env_ode$sv1_converted'
         symbol_t = local_model.get_symbol_by_cmeta_id('time')
         assert symbol_t.units == 'ms'
         symbol_orig = local_model.get_symbol_by_name('env_ode$sv1')
         assert symbol_orig.units == 'mV'
-        assert not local_model.get_initial_value(symbol_orig)
+        assert symbol_orig.initial_value is None
         symbol_derv = local_model.get_symbol_by_name('env_ode$sv1_orig_deriv')
         assert symbol_derv.units == 'mV / ms'
-        assert not local_model.get_initial_value(symbol_derv)
+        assert symbol_derv.initial_value is None
         assert len(local_model.equations) == 3
         assert str(local_model.equations[0]) == 'Eq(_env_ode$sv1, 1000.0*_env_ode$sv1_converted)'
         assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1.0)'
@@ -282,7 +282,7 @@ class TestUnitConversion:
         local_model.convert_variable(original_var, second_unit, DataDirectionFlow.INPUT)
         assert len(local_model.variables()) == 5
         symbol_a = local_model.get_symbol_by_cmeta_id('sv11')
-        assert local_model.get_initial_value(symbol_a) == 2.0
+        assert symbol_a.initial_value == 2.0
         assert symbol_a.units == 'mV'
         assert symbol_a.name == 'env_ode$sv1'
         symbol_t = local_model.get_symbol_by_cmeta_id('time')
@@ -345,11 +345,11 @@ class TestUnitConversion:
         assert symbol_x.name == 'env_ode$x_converted'
         symbol_y = literals_model.get_symbol_by_name('env_ode$y')
         symbol_x_orig = literals_model.get_symbol_by_name('env_ode$x')
-        assert literals_model.get_initial_value(symbol_a) == 2.0
-        assert not literals_model.get_initial_value(symbol_t)
-        assert not literals_model.get_initial_value(symbol_x)
-        assert not literals_model.get_initial_value(symbol_y)
-        assert not literals_model.get_initial_value(symbol_x_orig)
+        assert symbol_a.initial_value == 2.0
+        assert symbol_t.initial_value is None
+        assert symbol_x.initial_value is None
+        assert symbol_y.initial_value is None
+        assert symbol_x_orig.initial_value is None
         assert symbol_a.units == 'mV'
         assert symbol_t.units == 'ms'
         assert symbol_x.units == 'nA'
@@ -403,7 +403,7 @@ class TestUnitConversion:
         multiode_freevar_model.convert_variable(original_var, second_unit, DataDirectionFlow.INPUT)
         assert len(multiode_freevar_model.variables()) == 7
         symbol_a = multiode_freevar_model.get_symbol_by_cmeta_id('sv11')
-        assert multiode_freevar_model.get_initial_value(symbol_a) == 2.0
+        assert symbol_a.initial_value == 2.0
         assert symbol_a.units == 'mV'
         assert symbol_a.name == 'env_ode$sv1'
         symbol_t = multiode_freevar_model.get_symbol_by_cmeta_id('time')
@@ -592,11 +592,11 @@ class TestUnitConversion:
         assert symbol_x.name == 'env_ode$x_converted'
         symbol_y = literals_model.get_symbol_by_name('env_ode$y')
         symbol_x_orig = literals_model.get_symbol_by_name('env_ode$x')
-        assert literals_model.get_initial_value(symbol_a) == 2.0
-        assert not literals_model.get_initial_value(symbol_t)
-        assert not literals_model.get_initial_value(symbol_x)
-        assert not literals_model.get_initial_value(symbol_y)
-        assert not literals_model.get_initial_value(symbol_x_orig)
+        assert symbol_a.initial_value == 2.0
+        assert symbol_t.initial_value is None
+        assert symbol_x.initial_value is None
+        assert symbol_y.initial_value is None
+        assert symbol_x_orig.initial_value is None
         assert symbol_a.units == 'mV'
         assert symbol_t.units == 'ms'
         assert symbol_x.units == 'nA'
@@ -646,14 +646,14 @@ class TestUnitConversion:
         local_model.convert_variable(original_var, volt_unit, DataDirectionFlow.OUTPUT)
         assert len(local_model.variables()) == 4
         symbol_a = local_model.get_symbol_by_cmeta_id('sv11')
-        assert not local_model.get_initial_value(symbol_a)
+        assert symbol_a.initial_value is None
         assert symbol_a.units == 'volt'
         assert symbol_a.name == 'env_ode$sv1_converted'
         symbol_t = local_model.get_symbol_by_cmeta_id('time')
         assert symbol_t.units == 'ms'
         symbol_orig = local_model.get_symbol_by_name('env_ode$sv1')
         assert symbol_orig.units == 'mV'
-        assert local_model.get_initial_value(symbol_orig) == 2.0
+        assert symbol_orig.initial_value == 2.0
         assert len(local_model.equations) == 2
         assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
         assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_converted, 0.001*_env_ode$sv1)'
@@ -697,7 +697,7 @@ class TestUnitConversion:
         local_model.convert_variable(original_var, second_unit, DataDirectionFlow.OUTPUT)
         assert len(local_model.variables()) == 4
         symbol_a = local_model.get_symbol_by_cmeta_id('sv11')
-        assert local_model.get_initial_value(symbol_a) == 2.0
+        assert symbol_a.initial_value == 2.0
         assert symbol_a.units == 'mV'
         assert symbol_a.name == 'env_ode$sv1'
         symbol_t = local_model.get_symbol_by_cmeta_id('time')
@@ -761,7 +761,7 @@ class TestUnitConversion:
             assert len(silly_names.variables()) == 5
             symbol_a = silly_names.get_symbol_by_cmeta_id('sv11')
             symbol_t = silly_names.get_symbol_by_cmeta_id('time')
-            assert silly_names.get_initial_value(symbol_a) == 2.0
+            assert symbol_a.initial_value == 2.0
             assert symbol_a.units == 'mV'
             assert symbol_t.units == 'ms'
             assert silly_names.get_symbol_by_name('env_ode$sv1_converted')
@@ -782,7 +782,7 @@ class TestUnitConversion:
         silly_names.convert_variable(original_var, volt_unit, DataDirectionFlow.INPUT)
         assert len(silly_names.variables()) == 7
         symbol_a = silly_names.get_symbol_by_cmeta_id('sv11')
-        assert silly_names.get_initial_value(symbol_a) == 0.002
+        assert symbol_a.initial_value == 0.002
         assert symbol_a.units == 'volt'
         assert symbol_a.name == 'env_ode$sv1_converted_a'
         symbol_t = silly_names.get_symbol_by_cmeta_id('time')
@@ -794,7 +794,7 @@ class TestUnitConversion:
         assert silly_names.get_symbol_by_name('env_ode$sv1_orig_deriv')
         symbol_derv = silly_names.get_symbol_by_name('env_ode$sv1_orig_deriv_a')
         assert symbol_derv.units == 'mV / ms'
-        assert not silly_names.get_initial_value(symbol_derv)
+        assert symbol_derv.initial_value is None
         assert len(silly_names.equations) == 3
         assert str(silly_names.equations[0]) == 'Eq(_env_ode$sv1, 1000.0*_env_ode$sv1_converted_a)'
         assert str(silly_names.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv_a, _1.0)'


### PR DESCRIPTION
## Description

Ensures consistent handling of initial values (just for state variables) and parameters (always defined by an equation with RHS that's a number).

Also removed the `Model.get_initial_value` method, since for state vars you can just do `var.initial_value`.

## Motivation and Context

Will fix #201. Means we don't have initial_value meaning two different things, thus simplifies later processing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

