### PR TITLE
Add get_definition helper method for FC

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -492,6 +492,18 @@ class Model(object):
         """
         return self.units.get_quantity(name)
 
+    def get_definition(self, symbol):
+        """Get the equation (if any) defining the given variable.
+
+        :param symbol: the variable to look up. If this appears as the LHS of a straight assignment,
+            or the state variable in an ODE, the corresponding equation will be returned.
+        :returns: a Sympy equation, or ``None`` if the variable is not defined by an equation.
+        """
+        defn = self._ode_definition_map.get(symbol)
+        if defn is None:
+            defn = self._var_definition_map.get(symbol)
+        return defn
+
     @property
     def graph(self):
         """ A ``networkx.DiGraph`` containing the model equations. """

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -273,6 +273,22 @@ class TestModelFunctions():
         assert eqs[5] == e_y3
         assert len(eqs) == 6
 
+    def test_get_definition(self, simple_ode_model):
+        # Simple equation
+        a = simple_ode_model.get_symbol_by_cmeta_id('a2')
+        defn = simple_ode_model.get_definition(a)
+        assert str(defn) == 'Eq(_single_ode_rhs_computed_var$a, _-1.0)'
+
+        # ODE definition
+        state_var = simple_ode_model.get_symbol_by_cmeta_id('sv11')
+        defn = simple_ode_model.get_definition(state_var)
+        assert str(defn) == 'Eq(Derivative(_single_independent_ode$sv1, _environment$time), _1.0)'
+
+        # No defining equation
+        time = simple_ode_model.get_symbol_by_cmeta_id('time')
+        defn = simple_ode_model.get_definition(time)
+        assert defn is None
+
     def test_get_value(self, aslanidi_model):
         """ Tests Model.get_value() works correctly. """
 


### PR DESCRIPTION
## Description

Adds a simple `Model.get_definition` method.

## Motivation and Context

Functional curation needs to determine which equation a new equation replaces. For this it needs to find any equation currently defining the LHS, either as a normal equation or ODE for it as a state variable. This information is available in private maps within the `Model`; this method provides access via a public API.

See also https://github.com/ModellingWebLab/weblab-fc/pull/73.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

