### PR TITLE
Allow a UnitStore to be passed when loading a model

### DIFF
--- a/cellmlmanip/main.py
+++ b/cellmlmanip/main.py
@@ -5,7 +5,7 @@ from cellmlmanip.parser import Parser
 def load_model(path, unit_store=None):
     """Parses a CellML file and returns a :class:`cellmlmanip.Model`.
 
-	:param unit_store: Optional :class:`cellmlmanip.units.UnitStore` instance; if given the model will share the
+    :param unit_store: Optional :class:`cellmlmanip.units.UnitStore` instance; if given the model will share the
         underlying registry so that conversions between model units and those from the provided store work.
     """
     return Parser(path).parse(unit_store=unit_store)

--- a/cellmlmanip/main.py
+++ b/cellmlmanip/main.py
@@ -2,7 +2,11 @@
 from cellmlmanip.parser import Parser
 
 
-def load_model(path):
-    """Parses a CellML file and returns a :class:`cellmlmanip.Model`."""
-    return Parser(path).parse()
+def load_model(path, unit_store=None):
+    """Parses a CellML file and returns a :class:`cellmlmanip.Model`.
+
+	:param unit_store: Optional :class:`cellmlmanip.units.UnitStore` instance; if given the model will share the
+        underlying registry so that conversions between model units and those from the provided store work.
+    """
+    return Parser(path).parse(unit_store=unit_store)
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -332,7 +332,7 @@ class Model(object):
         The list is ordered by appearance in the cellml document.
         """
         derivative_symbols = [v for v in self.graph if isinstance(v, sympy.Derivative)]
-        return sorted(derivative_symbols, key=lambda state_var: state_var.args[0].order_added)
+        return sorted(derivative_symbols, key=lambda deriv: deriv.args[0].order_added)
 
     def get_derived_quantities(self):
         """Returns a list of derived quantities found in the given model graph.

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -44,9 +44,11 @@ class Model(object):
 
     :param name: the name of the model e.g. from ``<model name="">``.
     :param cmeta_id: An optional cmeta id, e.g. from ``<model cmeta:id="">``.
+    :param unit_store: Optional :class:`cellmlmanip.units.UnitStore` instance; if given the model will share the
+        underlying registry so that conversions between model units and those from the provided store work.
     """
 
-    def __init__(self, name, cmeta_id=None):
+    def __init__(self, name, cmeta_id=None, unit_store=None):
 
         self.name = name
         self.cmeta_id = cmeta_id
@@ -56,7 +58,10 @@ class Model(object):
         self.equations = []
 
         # A UnitStore object
-        self.units = UnitStore()
+        if unit_store:
+            self.units = UnitStore(unit_store)
+        else:
+            self.units = UnitStore()
 
         # Maps string variable names to sympy.Dummy objects
         self._name_to_symbol = dict()

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -97,11 +97,13 @@ class Parser(object):
         # A dictionary mapping component names to _Component objects
         self.components = OrderedDict()
 
-    def parse(self):
+    def parse(self, unit_store=None):
         """
         The main method that reads the XML file and extracts the relevant parts of the CellML model
         definition.
 
+        :param unit_store: Optional :class:`cellmlmanip.units.UnitStore` instance; if given the model will share the
+            underlying registry so that conversions between model units and those from the provided store work.
         :return: a :class:`Model` holding CellML model definition, reading for manipulation.
         """
 
@@ -116,7 +118,9 @@ class Parser(object):
 
         # <model> root node - initialise the model object
         model_xml = tree.getroot()
-        self.model = Model(model_xml.get('name'), model_xml.get(Parser.with_ns(XmlNs.CMETA, 'id')))
+        self.model = Model(model_xml.get('name'),
+                           model_xml.get(Parser.with_ns(XmlNs.CMETA, 'id')),
+                           unit_store=unit_store)
 
         # handle the child elements of <model>
         self._add_units(model_xml)

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -47,9 +47,10 @@ def check_dummy_assignment(model):
     return is_okay
 
 
-def load_model(name):
+def load_model(name, unit_store=None):
     """ Parses and returns one of the CellML test models """
     if name[-7:] != '.cellml':
         name += '.cellml'
-    return cellmlmanip.load_model(os.path.join(
-        os.path.dirname(__file__), 'cellml_files', name))
+    return cellmlmanip.load_model(
+        os.path.join(os.path.dirname(__file__), 'cellml_files', name),
+        unit_store=unit_store)


### PR DESCRIPTION
## Description

`load_model` and friends now have an optional `unit_store` parameter.

## Motivation and Context

From weblab-fc we need to pass the protocol's unit store to the loaded model so unit conversions work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

