### PR TITLE
Make get_symbol_by_ontology_term take a single argument

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -416,29 +416,29 @@ class Model(object):
         """ Returns the symbol for the variable with the given ``name``. """
         return self._name_to_symbol[name]
 
-    def get_symbol_by_ontology_term(self, namespace_uri, local_name):
-        """Searches the RDF graph for a variable annotated with the given
-        ``{namespace_uri}local_name`` and returns its symbol.
+    def get_symbol_by_ontology_term(self, term):
+        """Searches the RDF graph for a variable annotated with the given ``term`` and returns its symbol.
 
         Specifically, this method searches for a unique variable annotated with
         predicate ``http://biomodels.net/biology-qualifiers/is`` and the object
-        specified by ``{namespace_uri}local_name``.
+        specified by ``term``.
 
         Will raise a ``KeyError`` if no variable with the given annotation is
         found, and a ``ValueError`` if more than one variable with the given
         annotation is found.
+
+        :param term: anything suitable as an input to :meth:`create_rdf_node`; typically either an RDF
+            node already, or a tuple ``(namespace_uri, local_name)``.
         """
         symbols = self.get_symbols_by_rdf(
             ('http://biomodels.net/biology-qualifiers/', 'is'),
-            (namespace_uri, local_name))
+            term)
         if len(symbols) == 1:
             return symbols[0]
         elif not symbols:
-            raise KeyError('No variable annotated with {%s}%s found.' %
-                           (namespace_uri, local_name))
+            raise KeyError('No variable annotated with {} found.'.format(term))
         else:
-            raise ValueError('Multiple variables annotated with {%s}%s' %
-                             (namespace_uri, local_name))
+            raise ValueError('Multiple variables annotated with {}'.format(term))
 
     def get_symbols_by_rdf(self, predicate, object_=None):
         """Searches the RDF graph for variables annotated with the given predicate and object (e.g. "is oxmeta:time")

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -292,7 +292,7 @@ class TestModelFunctions():
     def test_get_value(self, aslanidi_model):
         """ Tests Model.get_value() works correctly. """
 
-        symbol_a = aslanidi_model.get_symbol_by_ontology_term(shared.OXMETA, "membrane_capacitance")
+        symbol_a = aslanidi_model.get_symbol_by_ontology_term((shared.OXMETA, "membrane_capacitance"))
         assert aslanidi_model.get_value(symbol_a) == 5e-5
 
     #################################################################
@@ -318,7 +318,7 @@ class TestModelFunctions():
     def test_get_symbol_by_ontology_term(self, aslanidi_model):
         """ Tests Model.get_symbol_by_ontology_term() works correctly. """
 
-        symbol_a = aslanidi_model.get_symbol_by_ontology_term(shared.OXMETA, 'membrane_capacitance')
+        symbol_a = aslanidi_model.get_symbol_by_ontology_term((shared.OXMETA, 'membrane_capacitance'))
         assert symbol_a.name == 'membrane$Cm'
         assert symbol_a.units == aslanidi_model.units.get_unit('nanoF')
 
@@ -398,7 +398,7 @@ class TestModelFunctions():
 
         model = local_hh_model
         # Get model, assert that V is a state variable
-        v = model.get_symbol_by_ontology_term(shared.OXMETA, 'membrane_voltage')
+        v = model.get_symbol_by_ontology_term((shared.OXMETA, 'membrane_voltage'))
         # the issue here is that retrieving the variable uses the internal structure
         # which does not give the variable a type
         # to check type you need to use the graph
@@ -407,14 +407,14 @@ class TestModelFunctions():
         assert v in state_var
 
         # Now clamp it to -80mV
-        t = model.get_symbol_by_ontology_term(shared.OXMETA, 'time')
+        t = model.get_symbol_by_ontology_term((shared.OXMETA, 'time'))
         equation = model.graph.nodes[sp.Derivative(v, t)]['equation']
         model.remove_equation(equation)
         equation = sp.Eq(v, model.add_number(-80, v.units))
         model.add_equation(equation)
 
         # Check that V is no longer a state
-        v = model.get_symbol_by_ontology_term(shared.OXMETA, 'membrane_voltage')
+        v = model.get_symbol_by_ontology_term((shared.OXMETA, 'membrane_voltage'))
         state_var = model.get_state_symbols()
         assert v not in state_var
 
@@ -425,7 +425,7 @@ class TestModelFunctions():
         model.add_equation(equation)
 
         # Check that V is a state again
-        v = model.get_symbol_by_ontology_term(shared.OXMETA, 'membrane_voltage')
+        v = model.get_symbol_by_ontology_term((shared.OXMETA, 'membrane_voltage'))
         state_var = model.get_state_symbols()
         assert v in state_var
 
@@ -551,7 +551,7 @@ class TestModelFunctions():
         assert len(syms) == 1
         assert t in syms
 
-        v = hh_model.get_symbol_by_ontology_term(shared.OXMETA, "membrane_voltage")
+        v = hh_model.get_symbol_by_ontology_term((shared.OXMETA, "membrane_voltage"))
         dvdt = sp.Derivative(v, t)
         syms = hh_model.find_symbols_and_derivatives([dvdt])
         assert len(syms) == 1

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -52,38 +52,38 @@ def test_get_symbol_by_ontology_term(simple_ode_model, bad_annotation_model):
     """ Tests Model.get_symbol_by_ontology_term() function. """
     # Test getting the time variable
     model = simple_ode_model
-    var = model.get_symbol_by_ontology_term(shared.OXMETA, 'time')
+    var = model.get_symbol_by_ontology_term((shared.OXMETA, 'time'))
     assert isinstance(var, sympy.Symbol)
     assert var.name == 'environment$time'
 
     # Test getting a non-existent variable
     with pytest.raises(KeyError):
-        model.get_symbol_by_ontology_term(shared.OXMETA, 'bert')
+        model.get_symbol_by_ontology_term((shared.OXMETA, 'bert'))
     with pytest.raises(KeyError):
-        model.get_symbol_by_ontology_term('http://example.com#', 'time')
+        model.get_symbol_by_ontology_term(('http://example.com#', 'time'))
 
     # Test bad annotations
     model = bad_annotation_model
 
     # Two variables with the same ID
     with pytest.raises(ValueError, match='Multiple variables annotated with'):
-        model.get_symbol_by_ontology_term(shared.OXMETA, 'time')
+        model.get_symbol_by_ontology_term((shared.OXMETA, 'time'))
 
     # Annotation with a cmeta id that doesn't exist
     with pytest.raises(KeyError, match='No variable with cmeta id'):
-        model.get_symbol_by_ontology_term(shared.OXMETA, 'membrane_potential')
+        model.get_symbol_by_ontology_term((shared.OXMETA, 'membrane_potential'))
 
     # Annotation of something that isn't a variable
     with pytest.raises(KeyError, match='No variable with cmeta id'):
         model.get_symbol_by_ontology_term(
-            shared.OXMETA, 'membrane_fast_sodium_current')
+            (shared.OXMETA, 'membrane_fast_sodium_current'))
 
     # Non-local annotation
     # TODO: Add support to allow non-local (but valid, i.e. referring to the
     #       current model) references.
     with pytest.raises(NotImplementedError, match='Non-local annotations'):
         model.get_symbol_by_ontology_term(
-            shared.OXMETA, 'membrane_persistent_sodium_current')
+            (shared.OXMETA, 'membrane_persistent_sodium_current'))
 
 
 def test_get_ontology_terms_by_symbol(bad_annotation_model):
@@ -100,7 +100,7 @@ def test_get_ontology_terms_by_symbol(bad_annotation_model):
 
 def test_get_ontology_terms_by_symbol2(hh_model):
     """ Tests Model.get_symbol_by_ontology_term() function when the annotation is not correct. """
-    membrane_voltage_var = hh_model.get_symbol_by_ontology_term(shared.OXMETA, "membrane_voltage")
+    membrane_voltage_var = hh_model.get_symbol_by_ontology_term((shared.OXMETA, "membrane_voltage"))
     annotation = hh_model.get_ontology_terms_by_symbol(membrane_voltage_var, shared.OXMETA)
     assert len(annotation) == 1
     assert annotation[0] == "membrane_voltage"
@@ -133,7 +133,7 @@ def test_has_ontology_term_by_symbol(bad_annotation_model):
 
 def test_has_ontology_annotation(hh_model):
     """ Tests Model.has_ontology_annotation() function. """
-    membrane_voltage_var = hh_model.get_symbol_by_ontology_term(shared.OXMETA, "membrane_voltage")
+    membrane_voltage_var = hh_model.get_symbol_by_ontology_term((shared.OXMETA, "membrane_voltage"))
     assert hh_model.has_ontology_annotation(membrane_voltage_var, shared.OXMETA)
 
     # Repeat test with wrong namespace

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -718,7 +718,7 @@ class TestUnitConversion:
         """ Tests the Model.convert_variable() function when conversion to current unit under a different name."""
         br_model.units.add_unit('millimolar', 'mole / 1000 / litre')
         unit = br_model.units.get_unit('concentration_units')
-        variable = br_model.get_symbol_by_ontology_term(shared.OXMETA, "cytosolic_calcium_concentration")
+        variable = br_model.get_symbol_by_ontology_term((shared.OXMETA, "cytosolic_calcium_concentration"))
         direction = DataDirectionFlow.INPUT
         assert br_model.convert_variable(variable, unit, direction) == variable
 


### PR DESCRIPTION
## Description

Change `Model.get_symbol_by_ontology_term` to take a single argument rather than namespace_uri and local_name separately.

## Motivation and Context

The single argument form is what `create_rdf_node` now takes, and means we can pass anything supported by that method. In particular, if we already have an RDF node, we can pass it directly rather than having to split it out into parts. This will simplify calling from weblab-fc.

Because it changes the calling signature, this will break existing code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

