### PR TITLE
Added cmeta id as (read-only) property.

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -1102,6 +1102,11 @@ class VariableDummy(sympy.Dummy):
         # TODO: Define allowed types via enum
         self.type = None
 
+    @property
+    def cmeta_id(self):
+        """Provides read-only access the the cmeta id."""
+        return self._cmeta_id
+
     def __str__(self):
         return self.name
 

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -15,6 +15,14 @@ def local_model(scope='module'):
     return shared.load_model('test_simple_odes')
 
 
+def test_cmeta_id(simple_ode_model):
+    """Tests access to a variable's cmeta id."""
+    var = simple_ode_model.get_symbol_by_cmeta_id('time')
+    assert var.cmeta_id == 'time'
+    with pytest.raises(AttributeError):
+        var.cmeta_id = 'hello'
+
+
 def test_create_rdf_node():
     """ Tests rdf.create_rdf_node() function. """
 


### PR DESCRIPTION
## Description
Read-only access to cmeta id was still needed for display purposes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

