### PR TITLE
We can just search for NumberDummy directly

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -622,11 +622,9 @@ class Model(object):
             if equation is None:
                 continue
 
-            # Get all the dummy symbols on the RHS
-            dummies = equation.rhs.atoms(sympy.Dummy)
-
-            # Get any dummy symbols which are placeholders for numbers
-            subs_dict = {d: sympy.Float(d.value, FLOAT_PRECISION) for d in dummies if isinstance(d, NumberDummy)}
+            # Get all the dummy numbers on the RHS, and prepare substitution map
+            dummies = equation.rhs.atoms(NumberDummy)
+            subs_dict = {d: sympy.Float(d.value, FLOAT_PRECISION) for d in dummies}
 
             # And replace the equation with one with the rhs subbed with sympy.Number objects
             if subs_dict:


### PR DESCRIPTION
## Description

I spotted a minor optimisation while reviewing #253. We can search directly for the `NumberDummy` instances, rather than finding all dummies then filtering.

## Types of changes
- New feature (non-breaking change which adds functionality) - kind of!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [x] Testing is done automatically and codecov shows test coverage
