### PR TITLE
Add ability to convert units within equations

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -1040,6 +1040,7 @@ class NumberDummy(sympy.Dummy):
         return self.value
 
     def _eval_evalf(self, prec):
+        """This is needed to allow Sympy's ``evalf`` method to represent this value as a float."""
         return sympy.Float(self.value, prec)
 
     def __str__(self):

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -1039,6 +1039,9 @@ class NumberDummy(sympy.Dummy):
     def __float__(self):
         return self.value
 
+    def _eval_evalf(self, prec):
+        return sympy.Float(self.value, prec)
+
     def __str__(self):
         return str(self.value)
 

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -713,7 +713,6 @@ class UnitCalculator(object):
 
         :returns: a tuple ``(new_expr, was_converted, actual_units)``
         """
-        print('Trying to convert {} {} to {}'.format(type(expr), expr, to_units))
         was_converted = False  # Tracks whether we needed a units conversion
         dimensionless = self._store.get_unit('dimensionless')
 
@@ -728,7 +727,6 @@ class UnitCalculator(object):
             except DimensionalityError:
                 raise UnitConversionError(expr, from_units, to_units) from None
             if cf != 1:
-                print('Converting {} to {} by factor {}'.format(from_units, to_units, cf))
                 was_converted = True
                 cf = model.NumberDummy(cf, to_units / from_units)
                 expr = cf * expr
@@ -854,5 +852,4 @@ class UnitCalculator(object):
         else:
             raise UnexpectedMathUnitsError(str(expr))
 
-        print('  Result for {} was converted? {} into {}'.format(expr, was_converted, actual_units))
         return expr, was_converted, actual_units

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -363,8 +363,8 @@ class UnitStore(object):
         :returns: the magnitude of the resulting conversion factor
         """
         assert isinstance(from_unit, self._registry.Unit), 'from_unit must be a unit, not ' + str(from_unit)
-        conversion_factor = self.convert(1 * from_unit, to_unit).magnitude
-        return 1.0 if math.isclose(conversion_factor, 1.0) else conversion_factor
+        cf = self.convert(1 * from_unit, to_unit).magnitude
+        return 1.0 if isinstance(cf, numbers.Number) and math.isclose(cf, 1.0) else cf
 
     def _prefix_expression(self, match):
         """Takes a regex Match object from _WORD, and adds a prefix (UnitStore id), taking SI prefixes into account."""

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -666,6 +666,21 @@ class UnitCalculator(object):
         new_expr, was_converted, actual_units = self._convert_expr_recursively(expr, to_units)
         return new_expr
 
+    def set_lhs_units_from_rhs(self, equation):
+        """Set the units of the variable assigned to based on the expression assigned.
+
+        :param equation: a :class:`sympy.Eq` instance with a :class:`VariableDummy` on the left hand side
+        :returns: a new version of the equation, but with the RHS using consistent units throughout (with
+            conversions if needed) and the ``units`` attribute on the LHS updated to match
+        """
+        lhs = equation.lhs
+        assert isinstance(lhs, model.VariableDummy)
+        new_rhs, was_converted, rhs_units = self._convert_expr_recursively(equation.rhs, None)
+        lhs.units = rhs_units
+        if was_converted:
+            equation = sympy.Eq(lhs, new_rhs)
+        return equation
+
     def _convert_expr_recursively(self, expr, to_units):
         """Helper method for :meth:`convert_expr_recursively` which does the heavy lifting.
 

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -680,7 +680,7 @@ class UnitCalculator(object):
             try:
                 cf = self._store.get_conversion_factor(to_units, from_units)
             except DimensionalityError:
-                raise UnitConversionError(expr, from_units, to_units)
+                raise UnitConversionError(expr, from_units, to_units) from None
             if cf != 1.0:
                 print('Converting {} to {} by factor {}'.format(from_units, to_units, cf))
                 was_converted = True
@@ -706,6 +706,7 @@ class UnitCalculator(object):
             # Just convert the result if needed
             _, was_converted, numerator_units = maybe_convert_child(expr.args[0], was_converted, None)
             _, was_converted, denominator_units = maybe_convert_child(expr.args[1][0], was_converted, None)
+            assert not was_converted  # Ensures both parts are simple symbols
             actual_units = numerator_units / denominator_units
             if to_units is not None:
                 expr, was_converted, actual_units = maybe_convert_expr(expr, was_converted, to_units, actual_units)
@@ -729,7 +730,7 @@ class UnitCalculator(object):
             try:
                 exponent_val = float(exponent)
             except TypeError:
-                raise InputArgumentMustBeNumberError(str(expr), 'second')
+                raise InputArgumentMustBeNumberError(str(expr), 'second') from None
             # Base can be any units, then (try to) convert the result if needed
             base, was_converted, base_units = maybe_convert_child(base, was_converted, None)
             if was_converted:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -673,6 +673,16 @@ class TestConvertingExpressions:
         assert new_expr.args[1] is _10
         assert x.units is ms
 
+    def test_set_lhs_units_from_converted_rhs(self, store, calculator, ms):
+        x = VariableDummy('x', None)
+        y = VariableDummy('y', store.get_unit('second'))
+        _10 = NumberDummy(10, ms)
+        expr = sp.Eq(x, _10 + y)
+        new_expr = calculator.set_lhs_units_from_rhs(expr)
+        assert str(new_expr) == 'Eq(_x, _10 + _1000.0*_y)'
+        assert new_expr.args[0] is x
+        assert x.units is ms
+
     # Methods below check error cases
     def test_symbol_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -656,6 +656,11 @@ class TestConvertingExpressions:
         assert str(new_expr) == (
             'Piecewise((_1000.0*_y, (_2 < _x) & (_y < _0.001*_z)), (_z, _2 > _x), (_2*_z, True))')
 
+        # A simpler case with no conversion
+        _1 = NumberDummy('1', ms)
+        expr = sp.Piecewise((z, x < _2), (_1, True))
+        assert calculator.convert_expr_recursively(expr, ms) is expr
+
     def test_assignment(self, store, calculator, ms):
         x = VariableDummy('x', store.get_unit('second'))
         _10 = NumberDummy(10, ms)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -691,14 +691,14 @@ class TestConvertingExpressions:
     # Methods below check error cases
     def test_symbol_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
-        with pytest.raises(UnitConversionError):
+        with pytest.raises(UnitConversionError, match='from meter to second'):
             calculator.convert_expression_recursively(x, store.get_unit('second'))
 
     def test_derivative_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
-        with pytest.raises(UnitConversionError):
+        with pytest.raises(UnitConversionError, match='Context: trying to convert'):
             calculator.convert_expression_recursively(expr, store.get_unit('metre'))
 
     def test_complex_derivative(self, store, calculator):
@@ -794,3 +794,11 @@ class TestConvertingExpressions:
         expr = sp.Integral(x**2, x)
         with pytest.raises(UnexpectedMathUnitsError):
             calculator.convert_expression_recursively(expr, None)
+
+    def test_set_lhs_units_from_inconsistent_rhs(self, store, calculator):
+        x = VariableDummy('x', None)
+        _10 = NumberDummy(10, store.get_unit('metre'))
+        _20 = NumberDummy(20, store.get_unit('second'))
+        expr = sp.Eq(x, _10 + _20)
+        with pytest.raises(UnitConversionError, match='Context: trying to set LHS units'):
+            new_expr = calculator.set_lhs_units_from_rhs(expr)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -796,4 +796,4 @@ class TestConvertingExpressions:
         _20 = NumberDummy(20, store.get_unit('second'))
         expr = sp.Eq(x, _10 + _20)
         with pytest.raises(UnitConversionError, match='Context: trying to set LHS units'):
-            new_expr = store.set_lhs_units_from_rhs(expr)
+            store.set_lhs_units_from_rhs(expr)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -450,19 +450,19 @@ class TestEvaluateUnits:
 
 
 class TestConvertingExpressions:
-    """Test the UnitCalculator.convert_expr_recursively and set_lhs_units_from_rhs methods."""
+    """Test the UnitCalculator.convert_expression_recursively and set_lhs_units_from_rhs methods."""
     def test_variable_no_conversion(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
 
-        new_x = calculator.convert_expr_recursively(x, None)
+        new_x = calculator.convert_expression_recursively(x, None)
         assert x is new_x
 
-        new_x = calculator.convert_expr_recursively(x, x.units)
+        new_x = calculator.convert_expression_recursively(x, x.units)
         assert x is new_x
 
     def test_variable_conversion(self, store, calculator, cm):
         x = VariableDummy('x', store.get_unit('metre'))
-        new_x = calculator.convert_expr_recursively(x, cm)
+        new_x = calculator.convert_expression_recursively(x, cm)
         assert str(new_x) == '_100.0*_x'
         assert new_x.args[1] is x
         assert isinstance(new_x.args[0], NumberDummy)
@@ -470,7 +470,7 @@ class TestConvertingExpressions:
 
     def test_number_conversion(self, store, calculator, cm):
         _5 = NumberDummy(5, cm)
-        new_5 = calculator.convert_expr_recursively(_5, store.get_unit('metre'))
+        new_5 = calculator.convert_expression_recursively(_5, store.get_unit('metre'))
         assert str(new_5) == '_0.01*_5'
         assert new_5.args[1] is _5
         assert isinstance(new_5.args[0], NumberDummy)
@@ -478,28 +478,28 @@ class TestConvertingExpressions:
 
     def test_plain_numbers(self, store, calculator):
         dimensionless = store.get_unit('dimensionless')
-        assert calculator.convert_expr_recursively(sp.E, dimensionless) is sp.E
-        assert calculator.convert_expr_recursively(sp.pi, None) is sp.pi
-        assert calculator.convert_expr_recursively(sp.oo, dimensionless) is sp.oo
-        assert calculator.convert_expr_recursively(sp.nan, None) is sp.nan
-        assert calculator.convert_expr_recursively(sp.true, dimensionless) is sp.true
-        assert calculator.convert_expr_recursively(sp.false, None) is sp.false
+        assert calculator.convert_expression_recursively(sp.E, dimensionless) is sp.E
+        assert calculator.convert_expression_recursively(sp.pi, None) is sp.pi
+        assert calculator.convert_expression_recursively(sp.oo, dimensionless) is sp.oo
+        assert calculator.convert_expression_recursively(sp.nan, None) is sp.nan
+        assert calculator.convert_expression_recursively(sp.true, dimensionless) is sp.true
+        assert calculator.convert_expression_recursively(sp.false, None) is sp.false
 
         expr = sp.Integer(2)
-        assert calculator.convert_expr_recursively(expr, dimensionless) is expr
+        assert calculator.convert_expression_recursively(expr, dimensionless) is expr
 
         expr = sp.Rational(2, 3)
-        assert calculator.convert_expr_recursively(expr, None) is expr
+        assert calculator.convert_expression_recursively(expr, None) is expr
 
     def test_derivative_no_conversion(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
 
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert expr is new_expr
 
-        new_expr = calculator.convert_expr_recursively(expr, x.units / t.units)
+        new_expr = calculator.convert_expression_recursively(expr, x.units / t.units)
         assert expr is new_expr
 
     def test_derivative_conversion(self, store, calculator, cm, ms):
@@ -507,12 +507,12 @@ class TestConvertingExpressions:
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
 
-        new_expr = calculator.convert_expr_recursively(expr, cm / t.units)
+        new_expr = calculator.convert_expression_recursively(expr, cm / t.units)
         assert str(new_expr) == '_100.0*Derivative(_x, _t)'
         assert new_expr.args[0].args[0] is x
         assert new_expr.args[0].args[1][0] is t
 
-        new_expr = calculator.convert_expr_recursively(expr, x.units / ms)
+        new_expr = calculator.convert_expression_recursively(expr, x.units / ms)
         assert str(new_expr) == '_0.001*Derivative(_x, _t)'
 
     def test_mul_and_pow(self, store, calculator, cm, ms):
@@ -521,11 +521,11 @@ class TestConvertingExpressions:
         expr = x / y  # Becomes x * (1/y)
 
         # No conversion
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert expr is new_expr
 
         # With conversion
-        new_expr = calculator.convert_expr_recursively(expr, store.get_unit('metre') / store.get_unit('second'))
+        new_expr = calculator.convert_expression_recursively(expr, store.get_unit('metre') / store.get_unit('second'))
         assert str(new_expr) == '_10.0*_x/_y'
         assert new_expr.args[2] is x
         assert new_expr.args[0].args[0] is y
@@ -534,18 +534,18 @@ class TestConvertingExpressions:
         _4 = NumberDummy('4', store.get_unit('second'))
         _2 = NumberDummy('2000', ms)
         expr = x ** (_4 / _2)
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert str(new_expr) == '_x**(_1000.0*_4/_2000)'
 
         # With a base that needs internal conversion
         expr = (y + _4) ** 2
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert str(new_expr) == '(_0.001*_y + _4)**2'
 
     def test_square_root(self, store, calculator, ms):
         x = VariableDummy('x', store.get_unit('second') ** 2)
         expr = x ** (1 / 2)
-        new_expr = calculator.convert_expr_recursively(expr, ms)
+        new_expr = calculator.convert_expression_recursively(expr, ms)
         assert str(new_expr) == '_1000.0*_x**0.5'
         assert new_expr.args[0].args[0] is x
 
@@ -556,41 +556,41 @@ class TestConvertingExpressions:
 
         # If no conversion is needed we get the original expression
         expr = y + NumberDummy('2', ms)
-        assert calculator.convert_expr_recursively(expr, ms) is expr
+        assert calculator.convert_expression_recursively(expr, ms) is expr
 
         # If we don't specify units, the first argument (y in canonical form) is chosen
         expr = z + x - y
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert str(new_expr) == '_0.001*_z + _1000.0*_x - _y'
 
-        new_expr = calculator.convert_expr_recursively(expr, microsecond)
+        new_expr = calculator.convert_expression_recursively(expr, microsecond)
         assert str(new_expr) == '-_1000.0*_y + _1000000.0*_x + _z'
 
     def test_abs_ceil_floor(self, store, calculator, ms):
         x = VariableDummy('x', store.get_unit('second'))
 
         expr = sp.Abs(x)
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert new_expr is expr
 
         expr = sp.Abs(x)
-        new_expr = calculator.convert_expr_recursively(expr, ms)
+        new_expr = calculator.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.Abs)
         assert str(new_expr) == 'Abs(_1000.0*_x)'
         assert new_expr.args[0].args[1] is x
 
         expr = sp.floor(x)
-        new_expr = calculator.convert_expr_recursively(expr, store.get_unit('second'))
+        new_expr = calculator.convert_expression_recursively(expr, store.get_unit('second'))
         assert new_expr is expr
 
         expr = sp.floor(x)
-        new_expr = calculator.convert_expr_recursively(expr, ms)
+        new_expr = calculator.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.floor)
         assert str(new_expr) == 'floor(_1000.0*_x)'
         assert new_expr.args[0].args[1] is x
 
         expr = sp.ceiling(x)
-        new_expr = calculator.convert_expr_recursively(expr, ms)
+        new_expr = calculator.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.ceiling)
         assert str(new_expr) == 'ceiling(_1000.0*_x)'
         assert new_expr.args[0].args[1] is x
@@ -602,15 +602,15 @@ class TestConvertingExpressions:
         z = VariableDummy('z', ms)
 
         expr = sp.exp(x)
-        assert calculator.convert_expr_recursively(expr, dimensionless) is expr
+        assert calculator.convert_expression_recursively(expr, dimensionless) is expr
 
         expr = sp.log(y / z)
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert isinstance(new_expr, sp.log)
         assert str(new_expr) == 'log(_1000.0*_y/_z)'
 
         expr = sp.sin(z / y)
-        new_expr = calculator.convert_expr_recursively(expr, dimensionless)
+        new_expr = calculator.convert_expression_recursively(expr, dimensionless)
         assert isinstance(new_expr, sp.sin)
         assert str(new_expr) == 'sin(_0.001*_z/_y)'
 
@@ -620,16 +620,16 @@ class TestConvertingExpressions:
         z = VariableDummy('z', ms)
 
         expr = y < z
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert str(new_expr) == '_y < _0.001*_z'
 
         expr = z > y
-        new_expr = calculator.convert_expr_recursively(expr, store.get_unit('dimensionless'))
+        new_expr = calculator.convert_expression_recursively(expr, store.get_unit('dimensionless'))
         assert str(new_expr) == '_z > _1000.0*_y'
 
         # Case with no conversion
         expr = x < z
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert new_expr is expr
 
     def test_piecewise(self, store, calculator, ms, microsecond, cm):
@@ -647,25 +647,25 @@ class TestConvertingExpressions:
         )
 
         # Units of result will be chosen from first case, i.e. second
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert str(new_expr) == (
             'Piecewise((_y, (_2 < _x) & (_y < _0.001*_z)), (_0.001*_z, _2 > _x), (_0.001*_2*_z, True))')
 
         # Units of result are specified
-        new_expr = calculator.convert_expr_recursively(expr, ms)
+        new_expr = calculator.convert_expression_recursively(expr, ms)
         assert str(new_expr) == (
             'Piecewise((_1000.0*_y, (_2 < _x) & (_y < _0.001*_z)), (_z, _2 > _x), (_2*_z, True))')
 
         # A simpler case with no conversion
         _1 = NumberDummy('1', ms)
         expr = sp.Piecewise((z, x < _2), (_1, True))
-        assert calculator.convert_expr_recursively(expr, ms) is expr
+        assert calculator.convert_expression_recursively(expr, ms) is expr
 
     def test_assignment(self, store, calculator, ms):
         x = VariableDummy('x', store.get_unit('second'))
         _10 = NumberDummy(10, ms)
         expr = sp.Eq(x, _10)
-        new_expr = calculator.convert_expr_recursively(expr, None)
+        new_expr = calculator.convert_expression_recursively(expr, None)
         assert str(new_expr) == 'Eq(_x, _0.001*_10)'
 
     def test_set_lhs_units_from_rhs(self, store, calculator, ms):
@@ -692,95 +692,95 @@ class TestConvertingExpressions:
     def test_symbol_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(x, store.get_unit('second'))
+            calculator.convert_expression_recursively(x, store.get_unit('second'))
 
     def test_derivative_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, store.get_unit('metre'))
+            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
 
     def test_mul_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         _1 = NumberDummy(1, store.get_unit('second'))
         expr = x * _1
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, store.get_unit('metre'))
+            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
 
     def test_error_matrix(self, store, calculator):
         expr = sp.Matrix([[1, 0], [0, 1]])
         with pytest.raises(UnexpectedMathUnitsError):
-            calculator.convert_expr_recursively(expr, None)
+            calculator.convert_expression_recursively(expr, None)
 
     def test_error_exponent_not_dimensionless(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         _1 = NumberDummy(1, store.get_unit('second'))
         expr = x ** _1
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, None)
+            calculator.convert_expression_recursively(expr, None)
 
     def test_error_exponent_not_number(self, store, calculator):
         x = VariableDummy('x', store.get_unit('dimensionless'))
         _1 = NumberDummy(1, store.get_unit('second'))
         expr = _1 ** x
         with pytest.raises(InputArgumentMustBeNumberError):
-            calculator.convert_expr_recursively(expr, None)
+            calculator.convert_expression_recursively(expr, None)
 
     def test_pow_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('second'))
         _2 = NumberDummy(2, store.get_unit('dimensionless'))
         expr = x ** _2
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, store.get_unit('second'))
+            calculator.convert_expression_recursively(expr, store.get_unit('second'))
 
     def test_add_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('second'))
         _2 = NumberDummy(2, store.get_unit('dimensionless'))
         expr = x + _2
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, None)
+            calculator.convert_expression_recursively(expr, None)
 
     def test_relational_must_be_dimensionless(self, store, calculator):
         x = VariableDummy('x', store.get_unit('second'))
         y = VariableDummy('y', store.get_unit('second'))
         expr = x < y
         with pytest.raises(BooleanUnitsError):
-            calculator.convert_expr_recursively(expr, store.get_unit('second'))
+            calculator.convert_expression_recursively(expr, store.get_unit('second'))
 
     def test_relational_dimension_mismatch(self, store, calculator):
         x = VariableDummy('x', store.get_unit('second'))
         y = VariableDummy('y', store.get_unit('metre'))
         expr = x <= y
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, store.get_unit('dimensionless'))
+            calculator.convert_expression_recursively(expr, store.get_unit('dimensionless'))
 
     def test_piecewise_condition_not_dimensionless(self, store, calculator):
         a = VariableDummy('a', store.get_unit('metre'))
         x = VariableDummy('x', store.get_unit('second'))
         expr = sp.Piecewise((a, x), (-a, True))
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, store.get_unit('metre'))
+            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
 
     def test_piecewise_cannot_convert_result(self, store, calculator):
         a = VariableDummy('a', store.get_unit('metre'))
         x = VariableDummy('x', store.get_unit('dimensionless'))
         expr = sp.Piecewise((a, x), (-a, True))
         with pytest.raises(UnitConversionError):
-            calculator.convert_expr_recursively(expr, store.get_unit('second'))
+            calculator.convert_expression_recursively(expr, store.get_unit('second'))
 
     def test_exp_must_be_dimensionless(self, store, calculator):
         x = VariableDummy('x', store.get_unit('dimensionless'))
         expr = sp.exp(x)
         with pytest.raises(InputArgumentsMustBeDimensionlessError):
-            calculator.convert_expr_recursively(expr, store.get_unit('second'))
+            calculator.convert_expression_recursively(expr, store.get_unit('second'))
 
     def test_number_must_be_dimensionless(self, store, calculator):
         with pytest.raises(InputArgumentsMustBeDimensionlessError):
-            calculator.convert_expr_recursively(sp.E, store.get_unit('second'))
+            calculator.convert_expression_recursively(sp.E, store.get_unit('second'))
 
     def test_error_unsupported_math(self, store, calculator):
         x = VariableDummy('x', store.get_unit('second'))
         expr = sp.Integral(x**2, x)
         with pytest.raises(UnexpectedMathUnitsError):
-            calculator.convert_expr_recursively(expr, None)
+            calculator.convert_expression_recursively(expr, None)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -20,11 +20,6 @@ def store():
 
 
 @pytest.fixture(scope='class')
-def calculator(store):
-    return store._calculator
-
-
-@pytest.fixture(scope='class')
 def cm(store):
     return store.add_unit('cm', '0.01 * metre')
 
@@ -450,82 +445,82 @@ class TestEvaluateUnits:
 
 
 class TestConvertingExpressions:
-    """Test the UnitCalculator.convert_expression_recursively and set_lhs_units_from_rhs methods."""
-    def test_variable_no_conversion(self, store, calculator):
+    """Test the UnitStore.convert_expression_recursively and set_lhs_units_from_rhs methods."""
+    def test_variable_no_conversion(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
 
-        new_x = calculator.convert_expression_recursively(x, None)
+        new_x = store.convert_expression_recursively(x, None)
         assert x is new_x
 
-        new_x = calculator.convert_expression_recursively(x, x.units)
+        new_x = store.convert_expression_recursively(x, x.units)
         assert x is new_x
 
-    def test_variable_conversion(self, store, calculator, cm):
+    def test_variable_conversion(self, store, cm):
         x = VariableDummy('x', store.get_unit('metre'))
-        new_x = calculator.convert_expression_recursively(x, cm)
+        new_x = store.convert_expression_recursively(x, cm)
         assert str(new_x) == '_100.0*_x'
         assert new_x.args[1] is x
         assert isinstance(new_x.args[0], NumberDummy)
         assert new_x.args[0].units == cm / store.get_unit('metre')
 
-    def test_number_conversion(self, store, calculator, cm):
+    def test_number_conversion(self, store, cm):
         _5 = NumberDummy(5, cm)
-        new_5 = calculator.convert_expression_recursively(_5, store.get_unit('metre'))
+        new_5 = store.convert_expression_recursively(_5, store.get_unit('metre'))
         assert str(new_5) == '_0.01*_5'
         assert new_5.args[1] is _5
         assert isinstance(new_5.args[0], NumberDummy)
         assert new_5.args[0].units == store.get_unit('metre') / cm
 
-    def test_plain_numbers(self, store, calculator):
+    def test_plain_numbers(self, store):
         dimensionless = store.get_unit('dimensionless')
-        assert calculator.convert_expression_recursively(sp.E, dimensionless) is sp.E
-        assert calculator.convert_expression_recursively(sp.pi, None) is sp.pi
-        assert calculator.convert_expression_recursively(sp.oo, dimensionless) is sp.oo
-        assert calculator.convert_expression_recursively(sp.nan, None) is sp.nan
-        assert calculator.convert_expression_recursively(sp.true, dimensionless) is sp.true
-        assert calculator.convert_expression_recursively(sp.false, None) is sp.false
+        assert store.convert_expression_recursively(sp.E, dimensionless) is sp.E
+        assert store.convert_expression_recursively(sp.pi, None) is sp.pi
+        assert store.convert_expression_recursively(sp.oo, dimensionless) is sp.oo
+        assert store.convert_expression_recursively(sp.nan, None) is sp.nan
+        assert store.convert_expression_recursively(sp.true, dimensionless) is sp.true
+        assert store.convert_expression_recursively(sp.false, None) is sp.false
 
         expr = sp.Integer(2)
-        assert calculator.convert_expression_recursively(expr, dimensionless) is expr
+        assert store.convert_expression_recursively(expr, dimensionless) is expr
 
         expr = sp.Rational(2, 3)
-        assert calculator.convert_expression_recursively(expr, None) is expr
+        assert store.convert_expression_recursively(expr, None) is expr
 
-    def test_derivative_no_conversion(self, store, calculator):
+    def test_derivative_no_conversion(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
 
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert expr is new_expr
 
-        new_expr = calculator.convert_expression_recursively(expr, x.units / t.units)
+        new_expr = store.convert_expression_recursively(expr, x.units / t.units)
         assert expr is new_expr
 
-    def test_derivative_conversion(self, store, calculator, cm, ms):
+    def test_derivative_conversion(self, store, cm, ms):
         x = VariableDummy('x', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
 
-        new_expr = calculator.convert_expression_recursively(expr, cm / t.units)
+        new_expr = store.convert_expression_recursively(expr, cm / t.units)
         assert str(new_expr) == '_100.0*Derivative(_x, _t)'
         assert new_expr.args[0].args[0] is x
         assert new_expr.args[0].args[1][0] is t
 
-        new_expr = calculator.convert_expression_recursively(expr, x.units / ms)
+        new_expr = store.convert_expression_recursively(expr, x.units / ms)
         assert str(new_expr) == '_0.001*Derivative(_x, _t)'
 
-    def test_mul_and_pow(self, store, calculator, cm, ms):
+    def test_mul_and_pow(self, store, cm, ms):
         x = VariableDummy('x', cm)
         y = VariableDummy('y', ms)
         expr = x / y  # Becomes x * (1/y)
 
         # No conversion
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert expr is new_expr
 
         # With conversion
-        new_expr = calculator.convert_expression_recursively(expr, store.get_unit('metre') / store.get_unit('second'))
+        new_expr = store.convert_expression_recursively(expr, store.get_unit('metre') / store.get_unit('second'))
         assert str(new_expr) == '_10.0*_x/_y'
         assert new_expr.args[2] is x
         assert new_expr.args[0].args[0] is y
@@ -534,105 +529,105 @@ class TestConvertingExpressions:
         _4 = NumberDummy('4', store.get_unit('second'))
         _2 = NumberDummy('2000', ms)
         expr = x ** (_4 / _2)
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert str(new_expr) == '_x**(_1000.0*_4/_2000)'
 
         # With a base that needs internal conversion
         expr = (y + _4) ** 2
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert str(new_expr) == '(_0.001*_y + _4)**2'
 
-    def test_square_root(self, store, calculator, ms):
+    def test_square_root(self, store, ms):
         x = VariableDummy('x', store.get_unit('second') ** 2)
         expr = x ** (1 / 2)
-        new_expr = calculator.convert_expression_recursively(expr, ms)
+        new_expr = store.convert_expression_recursively(expr, ms)
         assert str(new_expr) == '_1000.0*_x**0.5'
         assert new_expr.args[0].args[0] is x
 
-    def test_add_and_subtract(self, store, calculator, ms, microsecond):
+    def test_add_and_subtract(self, store, ms, microsecond):
         x = VariableDummy('x', store.get_unit('second'))
         y = VariableDummy('y', ms)
         z = VariableDummy('z', microsecond)
 
         # If no conversion is needed we get the original expression
         expr = y + NumberDummy('2', ms)
-        assert calculator.convert_expression_recursively(expr, ms) is expr
+        assert store.convert_expression_recursively(expr, ms) is expr
 
         # If we don't specify units, the first argument (y in canonical form) is chosen
         expr = z + x - y
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert str(new_expr) == '_0.001*_z + _1000.0*_x - _y'
 
-        new_expr = calculator.convert_expression_recursively(expr, microsecond)
+        new_expr = store.convert_expression_recursively(expr, microsecond)
         assert str(new_expr) == '-_1000.0*_y + _1000000.0*_x + _z'
 
-    def test_abs_ceil_floor(self, store, calculator, ms):
+    def test_abs_ceil_floor(self, store, ms):
         x = VariableDummy('x', store.get_unit('second'))
 
         expr = sp.Abs(x)
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert new_expr is expr
 
         expr = sp.Abs(x)
-        new_expr = calculator.convert_expression_recursively(expr, ms)
+        new_expr = store.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.Abs)
         assert str(new_expr) == 'Abs(_1000.0*_x)'
         assert new_expr.args[0].args[1] is x
 
         expr = sp.floor(x)
-        new_expr = calculator.convert_expression_recursively(expr, store.get_unit('second'))
+        new_expr = store.convert_expression_recursively(expr, store.get_unit('second'))
         assert new_expr is expr
 
         expr = sp.floor(x)
-        new_expr = calculator.convert_expression_recursively(expr, ms)
+        new_expr = store.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.floor)
         assert str(new_expr) == 'floor(_1000.0*_x)'
         assert new_expr.args[0].args[1] is x
 
         expr = sp.ceiling(x)
-        new_expr = calculator.convert_expression_recursively(expr, ms)
+        new_expr = store.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.ceiling)
         assert str(new_expr) == 'ceiling(_1000.0*_x)'
         assert new_expr.args[0].args[1] is x
 
-    def test_exp_log_trig(self, store, calculator, ms):
+    def test_exp_log_trig(self, store, ms):
         dimensionless = store.get_unit('dimensionless')
         x = VariableDummy('x', dimensionless)
         y = VariableDummy('y', store.get_unit('second'))
         z = VariableDummy('z', ms)
 
         expr = sp.exp(x)
-        assert calculator.convert_expression_recursively(expr, dimensionless) is expr
+        assert store.convert_expression_recursively(expr, dimensionless) is expr
 
         expr = sp.log(y / z)
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert isinstance(new_expr, sp.log)
         assert str(new_expr) == 'log(_1000.0*_y/_z)'
 
         expr = sp.sin(z / y)
-        new_expr = calculator.convert_expression_recursively(expr, dimensionless)
+        new_expr = store.convert_expression_recursively(expr, dimensionless)
         assert isinstance(new_expr, sp.sin)
         assert str(new_expr) == 'sin(_0.001*_z/_y)'
 
-    def test_relations(self, store, calculator, ms):
+    def test_relations(self, store, ms):
         x = VariableDummy('x', ms)
         y = VariableDummy('y', store.get_unit('second'))
         z = VariableDummy('z', ms)
 
         expr = y < z
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert str(new_expr) == '_y < _0.001*_z'
 
         expr = z > y
-        new_expr = calculator.convert_expression_recursively(expr, store.get_unit('dimensionless'))
+        new_expr = store.convert_expression_recursively(expr, store.get_unit('dimensionless'))
         assert str(new_expr) == '_z > _1000.0*_y'
 
         # Case with no conversion
         expr = x < z
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert new_expr is expr
 
-    def test_piecewise(self, store, calculator, ms, microsecond, cm):
+    def test_piecewise(self, store, ms, microsecond, cm):
         # This also checks more complex nested expressions
         dimensionless = store.get_unit('dimensionless')
         _2 = NumberDummy(2, dimensionless)
@@ -647,61 +642,61 @@ class TestConvertingExpressions:
         )
 
         # Units of result will be chosen from first case, i.e. second
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert str(new_expr) == (
             'Piecewise((_y, (_2 < _x) & (_y < _0.001*_z)), (_0.001*_z, _2 > _x), (_0.001*_2*_z, True))')
 
         # Units of result are specified
-        new_expr = calculator.convert_expression_recursively(expr, ms)
+        new_expr = store.convert_expression_recursively(expr, ms)
         assert str(new_expr) == (
             'Piecewise((_1000.0*_y, (_2 < _x) & (_y < _0.001*_z)), (_z, _2 > _x), (_2*_z, True))')
 
         # A simpler case with no conversion
         _1 = NumberDummy('1', ms)
         expr = sp.Piecewise((z, x < _2), (_1, True))
-        assert calculator.convert_expression_recursively(expr, ms) is expr
+        assert store.convert_expression_recursively(expr, ms) is expr
 
-    def test_assignment(self, store, calculator, ms):
+    def test_assignment(self, store, ms):
         x = VariableDummy('x', store.get_unit('second'))
         _10 = NumberDummy(10, ms)
         expr = sp.Eq(x, _10)
-        new_expr = calculator.convert_expression_recursively(expr, None)
+        new_expr = store.convert_expression_recursively(expr, None)
         assert str(new_expr) == 'Eq(_x, _0.001*_10)'
 
-    def test_set_lhs_units_from_rhs(self, store, calculator, ms):
+    def test_set_lhs_units_from_rhs(self, store, ms):
         x = VariableDummy('x', None)
         _10 = NumberDummy(10, ms)
         expr = sp.Eq(x, _10)
-        new_expr = calculator.set_lhs_units_from_rhs(expr)
+        new_expr = store.set_lhs_units_from_rhs(expr)
         assert str(new_expr) == 'Eq(_x, _10)'
         assert new_expr.args[0] is x
         assert new_expr.args[1] is _10
         assert x.units is ms
 
-    def test_set_lhs_units_from_converted_rhs(self, store, calculator, ms):
+    def test_set_lhs_units_from_converted_rhs(self, store, ms):
         x = VariableDummy('x', None)
         y = VariableDummy('y', store.get_unit('second'))
         _10 = NumberDummy(10, ms)
         expr = sp.Eq(x, _10 + y)
-        new_expr = calculator.set_lhs_units_from_rhs(expr)
+        new_expr = store.set_lhs_units_from_rhs(expr)
         assert str(new_expr) == 'Eq(_x, _10 + _1000.0*_y)'
         assert new_expr.args[0] is x
         assert x.units is ms
 
     # Methods below check error cases
-    def test_symbol_wrong_dimensions(self, store, calculator):
+    def test_symbol_wrong_dimensions(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
         with pytest.raises(UnitConversionError, match='from meter to second'):
-            calculator.convert_expression_recursively(x, store.get_unit('second'))
+            store.convert_expression_recursively(x, store.get_unit('second'))
 
-    def test_derivative_wrong_dimensions(self, store, calculator):
+    def test_derivative_wrong_dimensions(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
         expr = sp.Derivative(x, t)
         with pytest.raises(UnitConversionError, match='Context: trying to convert'):
-            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
+            store.convert_expression_recursively(expr, store.get_unit('metre'))
 
-    def test_complex_derivative(self, store, calculator):
+    def test_complex_derivative(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
         y = VariableDummy('y', store.get_unit('metre'))
         t = VariableDummy('t', store.get_unit('second'))
@@ -709,96 +704,96 @@ class TestConvertingExpressions:
         expr = sp.Derivative(x + y, t, t2)
         with pytest.raises(UnexpectedMathUnitsError,
                            match='only support first order derivatives of single variables'):
-            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
+            store.convert_expression_recursively(expr, store.get_unit('metre'))
 
-    def test_mul_wrong_dimensions(self, store, calculator):
+    def test_mul_wrong_dimensions(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
         _1 = NumberDummy(1, store.get_unit('second'))
         expr = x * _1
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
+            store.convert_expression_recursively(expr, store.get_unit('metre'))
 
-    def test_error_matrix(self, store, calculator):
+    def test_error_matrix(self, store):
         expr = sp.Matrix([[1, 0], [0, 1]])
         with pytest.raises(UnexpectedMathUnitsError):
-            calculator.convert_expression_recursively(expr, None)
+            store.convert_expression_recursively(expr, None)
 
-    def test_error_exponent_not_dimensionless(self, store, calculator):
+    def test_error_exponent_not_dimensionless(self, store):
         x = VariableDummy('x', store.get_unit('metre'))
         _1 = NumberDummy(1, store.get_unit('second'))
         expr = x ** _1
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, None)
+            store.convert_expression_recursively(expr, None)
 
-    def test_error_exponent_not_number(self, store, calculator):
+    def test_error_exponent_not_number(self, store):
         x = VariableDummy('x', store.get_unit('dimensionless'))
         _1 = NumberDummy(1, store.get_unit('second'))
         expr = _1 ** x
         with pytest.raises(InputArgumentMustBeNumberError):
-            calculator.convert_expression_recursively(expr, None)
+            store.convert_expression_recursively(expr, None)
 
-    def test_pow_wrong_dimensions(self, store, calculator):
+    def test_pow_wrong_dimensions(self, store):
         x = VariableDummy('x', store.get_unit('second'))
         _2 = NumberDummy(2, store.get_unit('dimensionless'))
         expr = x ** _2
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, store.get_unit('second'))
+            store.convert_expression_recursively(expr, store.get_unit('second'))
 
-    def test_add_wrong_dimensions(self, store, calculator):
+    def test_add_wrong_dimensions(self, store):
         x = VariableDummy('x', store.get_unit('second'))
         _2 = NumberDummy(2, store.get_unit('dimensionless'))
         expr = x + _2
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, None)
+            store.convert_expression_recursively(expr, None)
 
-    def test_relational_must_be_dimensionless(self, store, calculator):
+    def test_relational_must_be_dimensionless(self, store):
         x = VariableDummy('x', store.get_unit('second'))
         y = VariableDummy('y', store.get_unit('second'))
         expr = x < y
         with pytest.raises(BooleanUnitsError):
-            calculator.convert_expression_recursively(expr, store.get_unit('second'))
+            store.convert_expression_recursively(expr, store.get_unit('second'))
 
-    def test_relational_dimension_mismatch(self, store, calculator):
+    def test_relational_dimension_mismatch(self, store):
         x = VariableDummy('x', store.get_unit('second'))
         y = VariableDummy('y', store.get_unit('metre'))
         expr = x <= y
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, store.get_unit('dimensionless'))
+            store.convert_expression_recursively(expr, store.get_unit('dimensionless'))
 
-    def test_piecewise_condition_not_dimensionless(self, store, calculator):
+    def test_piecewise_condition_not_dimensionless(self, store):
         a = VariableDummy('a', store.get_unit('metre'))
         x = VariableDummy('x', store.get_unit('second'))
         expr = sp.Piecewise((a, x), (-a, True))
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
+            store.convert_expression_recursively(expr, store.get_unit('metre'))
 
-    def test_piecewise_cannot_convert_result(self, store, calculator):
+    def test_piecewise_cannot_convert_result(self, store):
         a = VariableDummy('a', store.get_unit('metre'))
         x = VariableDummy('x', store.get_unit('dimensionless'))
         expr = sp.Piecewise((a, x), (-a, True))
         with pytest.raises(UnitConversionError):
-            calculator.convert_expression_recursively(expr, store.get_unit('second'))
+            store.convert_expression_recursively(expr, store.get_unit('second'))
 
-    def test_exp_must_be_dimensionless(self, store, calculator):
+    def test_exp_must_be_dimensionless(self, store):
         x = VariableDummy('x', store.get_unit('dimensionless'))
         expr = sp.exp(x)
         with pytest.raises(InputArgumentsMustBeDimensionlessError):
-            calculator.convert_expression_recursively(expr, store.get_unit('second'))
+            store.convert_expression_recursively(expr, store.get_unit('second'))
 
-    def test_number_must_be_dimensionless(self, store, calculator):
+    def test_number_must_be_dimensionless(self, store):
         with pytest.raises(InputArgumentsMustBeDimensionlessError):
-            calculator.convert_expression_recursively(sp.E, store.get_unit('second'))
+            store.convert_expression_recursively(sp.E, store.get_unit('second'))
 
-    def test_error_unsupported_math(self, store, calculator):
+    def test_error_unsupported_math(self, store):
         x = VariableDummy('x', store.get_unit('second'))
         expr = sp.Integral(x**2, x)
         with pytest.raises(UnexpectedMathUnitsError):
-            calculator.convert_expression_recursively(expr, None)
+            store.convert_expression_recursively(expr, None)
 
-    def test_set_lhs_units_from_inconsistent_rhs(self, store, calculator):
+    def test_set_lhs_units_from_inconsistent_rhs(self, store):
         x = VariableDummy('x', None)
         _10 = NumberDummy(10, store.get_unit('metre'))
         _20 = NumberDummy(20, store.get_unit('second'))
         expr = sp.Eq(x, _10 + _20)
         with pytest.raises(UnitConversionError, match='Context: trying to set LHS units'):
-            new_expr = calculator.set_lhs_units_from_rhs(expr)
+            new_expr = store.set_lhs_units_from_rhs(expr)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -450,7 +450,7 @@ class TestEvaluateUnits:
 
 
 class TestConvertingExpressions:
-    """Test the UnitCalculator.convert_expr_recursively method."""
+    """Test the UnitCalculator.convert_expr_recursively and set_lhs_units_from_rhs methods."""
     def test_variable_no_conversion(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
 
@@ -655,6 +655,23 @@ class TestConvertingExpressions:
         new_expr = calculator.convert_expr_recursively(expr, ms)
         assert str(new_expr) == (
             'Piecewise((_1000.0*_y, (_2 < _x) & (_y < _0.001*_z)), (_z, _2 > _x), (_2*_z, True))')
+
+    def test_assignment(self, store, calculator, ms):
+        x = VariableDummy('x', store.get_unit('second'))
+        _10 = NumberDummy(10, ms)
+        expr = sp.Eq(x, _10)
+        new_expr = calculator.convert_expr_recursively(expr, None)
+        assert str(new_expr) == 'Eq(_x, _0.001*_10)'
+
+    def test_set_lhs_units_from_rhs(self, store, calculator, ms):
+        x = VariableDummy('x', None)
+        _10 = NumberDummy(10, ms)
+        expr = sp.Eq(x, _10)
+        new_expr = calculator.set_lhs_units_from_rhs(expr)
+        assert str(new_expr) == 'Eq(_x, _10)'
+        assert new_expr.args[0] is x
+        assert new_expr.args[1] is _10
+        assert x.units is ms
 
     # Methods below check error cases
     def test_symbol_wrong_dimensions(self, store, calculator):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -701,6 +701,16 @@ class TestConvertingExpressions:
         with pytest.raises(UnitConversionError):
             calculator.convert_expression_recursively(expr, store.get_unit('metre'))
 
+    def test_complex_derivative(self, store, calculator):
+        x = VariableDummy('x', store.get_unit('metre'))
+        y = VariableDummy('y', store.get_unit('metre'))
+        t = VariableDummy('t', store.get_unit('second'))
+        t2 = VariableDummy('t2', store.get_unit('second'))
+        expr = sp.Derivative(x + y, t, t2)
+        with pytest.raises(UnexpectedMathUnitsError,
+                           match='only support first order derivatives of single variables'):
+            calculator.convert_expression_recursively(expr, store.get_unit('metre'))
+
     def test_mul_wrong_dimensions(self, store, calculator):
         x = VariableDummy('x', store.get_unit('metre'))
         _1 = NumberDummy(1, store.get_unit('second'))

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -29,11 +29,9 @@ def cm(store):
     return store.add_unit('cm', '0.01 * metre')
 
 
-
 @pytest.fixture(scope='class')
 def ms(store):
     return store.add_unit('ms', '0.001 * second')
-
 
 
 @pytest.fixture(scope='class')
@@ -546,7 +544,7 @@ class TestConvertingExpressions:
 
     def test_square_root(self, store, calculator, ms):
         x = VariableDummy('x', store.get_unit('second') ** 2)
-        expr = x ** (1/2)
+        expr = x ** (1 / 2)
         new_expr = calculator.convert_expr_recursively(expr, ms)
         assert str(new_expr) == '_1000.0*_x**0.5'
         assert new_expr.args[0].args[0] is x


### PR DESCRIPTION
## Description

Adds a `UnitCalculator.convert_expr_recursively` method to create a version of a Sympy expression with units conversions applied wherever necessary within the tree to ensure units match throughout (e.g. comparisons are always between quantities in the same units).

## Motivation and Context

Needed for https://github.com/ModellingWebLab/weblab-fc/issues/106

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [x] Testing is done automatically and codecov shows test coverage
