### PR TITLE
Unit conversion factors should have explicit units

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -647,7 +647,7 @@ class Model(object):
 
             # Get all the dummy numbers on the RHS, and prepare substitution map
             dummies = equation.rhs.atoms(NumberDummy)
-            subs_dict = {d: sympy.Float(d.value, FLOAT_PRECISION) for d in dummies}
+            subs_dict = {d: d.evalf(FLOAT_PRECISION) for d in dummies}
 
             # And replace the equation with one with the rhs subbed with sympy.Number objects
             if subs_dict:
@@ -1073,9 +1073,12 @@ class NumberDummy(sympy.Dummy):
 
     Unlike sympy expressions, this number type will never be removed in simplify operations etc.
 
-    Number dummies should never be created directly, but always via :meth:`Model.add_number()`
+    Number dummies should never be created directly, but always via :meth:`Model.add_number()`.
 
     Assumes the value is real.
+
+    To get the actual value as a float or string, use ``float(dummy)`` or ``str(dummy)`` respectively.
+    You can also use ``dummy.evalf()`` to get the value as a :class:`sympy.Float`.
     """
 
     # Sympy annoyingly overwrites __new__

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -880,6 +880,8 @@ class Model(object):
         if cf == 1:
             # No conversion necessary. The method above will ensure a factor close to 1 is returned as 1.
             return original_variable
+        # Make the conversion factor a number symbol with explicit units
+        cf = self.add_number(cf, units / original_variable.units)
 
         # Store original state and free symbols (these might change, so need to store references early)
         state_symbols = self.get_state_variables()
@@ -1017,7 +1019,7 @@ class Model(object):
         # If original has initial_value calculate converted initial value (only needed for INPUT case)
         new_initial_value = None
         if direction == DataDirectionFlow.INPUT and original_variable.initial_value is not None:
-            new_initial_value = original_variable.initial_value * cf
+            new_initial_value = original_variable.initial_value * float(cf)
 
         # Create new variable
         new_variable = self.add_variable(name=new_name, units=units, initial_value=new_initial_value)
@@ -1078,14 +1080,17 @@ class NumberDummy(sympy.Dummy):
 
     # Sympy annoyingly overwrites __new__
     def __new__(cls, value, *args, **kwargs):
-        return super().__new__(cls, str(value), real=True)
+        # Middle argument is the symbol name, so must be a string
+        if not isinstance(value, str):
+            value = '{:g}'.format(value)
+        return super().__new__(cls, value, real=True)
 
     def __init__(self, value, units):
-        self.value = float(value)
+        self.value = value
         self.units = units
 
     def __float__(self):
-        return self.value
+        return float(self.value)
 
     def _eval_evalf(self, prec):
         """This is needed to allow Sympy's ``evalf`` method to represent this value as a float."""

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -1089,18 +1089,18 @@ class NumberDummy(sympy.Dummy):
         return super().__new__(cls, value, real=True)
 
     def __init__(self, value, units):
-        self.value = value
+        self._value = value
         self.units = units
 
     def __float__(self):
-        return float(self.value)
+        return float(self._value)
 
     def _eval_evalf(self, prec):
         """This is needed to allow Sympy's ``evalf`` method to represent this value as a float."""
-        return sympy.Float(self.value, prec)
+        return sympy.Float(self._value, prec)
 
     def __str__(self):
-        return str(self.value)
+        return str(self._value)
 
 
 class VariableDummy(sympy.Dummy):

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -547,7 +547,7 @@ class Model(object):
 
     def get_value(self, variable):
         """ Returns the evaluated value of the given variable's RHS. """
-        return float(self.graph.nodes[variable]['equation'].rhs.evalf())
+        return float(self.graph.nodes[variable]['equation'].rhs)
 
     @property
     def graph(self):

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -318,12 +318,12 @@ class TestModelFunctions():
         # Simple equation
         a = simple_ode_model.get_variable_by_cmeta_id('a2')
         defn = simple_ode_model.get_definition(a)
-        assert str(defn) == 'Eq(_single_ode_rhs_computed_var$a, _-1.0)'
+        assert str(defn) == 'Eq(_single_ode_rhs_computed_var$a, _-1)'
 
         # ODE definition
         state_var = simple_ode_model.get_variable_by_cmeta_id('sv11')
         defn = simple_ode_model.get_definition(state_var)
-        assert str(defn) == 'Eq(Derivative(_single_independent_ode$sv1, _environment$time), _1.0)'
+        assert str(defn) == 'Eq(Derivative(_single_independent_ode$sv1, _environment$time), _1)'
 
         # No defining equation
         time = simple_ode_model.get_variable_by_cmeta_id('time')

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -675,7 +675,7 @@ class TestModelFunctions():
         assert new_eqn.is_Equality
         assert new_eqn.lhs == new_target
         assert new_eqn.rhs.is_Mul
-        assert new_eqn.rhs.args[0].value == 0.001
+        assert float(new_eqn.rhs.args[0]) == 0.001
         assert new_eqn.rhs.args[1] == source
 
     def test_variable_classification(self, aslanidi_model):

--- a/tests/test_unit_conversion.py
+++ b/tests/test_unit_conversion.py
@@ -78,7 +78,7 @@ class TestUnitConversion:
         my_nV = store.get_unit('my_nV')
         new_var = model.convert_variable(original_var, my_nV, DataDirectionFlow.OUTPUT)
         assert new_var != original_var
-        assert str(model.get_definition(new_var)) == 'Eq(_env_ode$sv1_converted, 1000000.0*_env_ode$sv1)'
+        assert str(model.get_definition(new_var)) == 'Eq(_env_ode$sv1_converted, _1e+06*_env_ode$sv1)'
 
     ###############################################################
     # Helper functions for later tests
@@ -92,7 +92,7 @@ class TestUnitConversion:
         assert symbol_a.units == local_model.units.get_unit('mV')
         assert symbol_t.units == local_model.units.get_unit('ms')
         assert len(local_model.equations) == 1
-        assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
+        assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
         states = local_model.get_state_variables()
         assert len(states) == 1
         assert symbol_a in states
@@ -115,9 +115,9 @@ class TestUnitConversion:
         assert symbol_x.units == literals_model.units.get_unit('pA')
         assert symbol_y.units == literals_model.units.get_unit('per_pA')
         assert len(literals_model.equations) == 3
-        assert str(literals_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
-        assert str(literals_model.equations[1]) == 'Eq(_env_ode$x, _1.0)'
-        assert str(literals_model.equations[2]) == 'Eq(_env_ode$y, _1.0/_env_ode$x)'
+        assert str(literals_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
+        assert str(literals_model.equations[1]) == 'Eq(_env_ode$x, _1)'
+        assert str(literals_model.equations[2]) == 'Eq(_env_ode$y, _1/_env_ode$x)'
         return True
 
     # original state for multiode_model
@@ -129,10 +129,10 @@ class TestUnitConversion:
         assert symbol_a.units == multiode_model.units.get_unit('mV')
         assert symbol_t.units == multiode_model.units.get_unit('ms')
         assert len(multiode_model.equations) == 3
-        assert str(multiode_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
+        assert str(multiode_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
         assert str(multiode_model.equations[1]) == \
-            'Eq(_env_ode$x, _1.0 + _3.0*Derivative(_env_ode$sv1, _environment$time))'
-        assert str(multiode_model.equations[2]) == 'Eq(Derivative(_env_ode$y, _environment$time), _2.0)'
+            'Eq(_env_ode$x, _1 + _3*Derivative(_env_ode$sv1, _environment$time))'
+        assert str(multiode_model.equations[2]) == 'Eq(Derivative(_env_ode$y, _environment$time), _2)'
         return True
 
     # original state
@@ -147,8 +147,8 @@ class TestUnitConversion:
         assert symbol_t.units == multiode_freevar_model.units.get_unit('ms')
         assert symbol_y.units == multiode_freevar_model.units.get_unit('mV')
         assert len(multiode_freevar_model.equations) == 2
-        assert str(multiode_freevar_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
-        assert str(multiode_freevar_model.equations[1]) == 'Eq(Derivative(_env_ode$y, _environment$time), _2.0)'
+        assert str(multiode_freevar_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
+        assert str(multiode_freevar_model.equations[1]) == 'Eq(Derivative(_env_ode$y, _environment$time), _2)'
         return True
 
     ###############################################################
@@ -205,10 +205,10 @@ class TestUnitConversion:
         assert symbol_derv.units == local_model.units.get_unit('mV') / local_model.units.get_unit('ms')
         assert symbol_derv.initial_value is None
         assert len(local_model.equations) == 3
-        assert str(local_model.equations[0]) == 'Eq(_env_ode$sv1, 1000.0*_env_ode$sv1_converted)'
-        assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1.0)'
+        assert str(local_model.equations[0]) == 'Eq(_env_ode$sv1, _env_ode$sv1_converted/_0.001)'
+        assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1)'
         assert str(local_model.equations[2]) == 'Eq(Derivative(_env_ode$sv1_converted, _environment$time), ' \
-                                                '0.001*_env_ode$sv1_orig_deriv)'
+                                                '_0.001*_env_ode$sv1_orig_deriv)'
 
         states = local_model.get_state_variables()
         assert len(states) == 1
@@ -276,10 +276,10 @@ class TestUnitConversion:
         symbol_derv = local_model.get_variable_by_name('env_ode$sv1_orig_deriv')
         assert symbol_derv.units == local_model.units.get_unit('mV') / local_model.units.get_unit('ms')
         assert len(local_model.equations) == 3
-        assert str(local_model.equations[0]) == 'Eq(_environment$time, 1000.0*_environment$time_converted)'
-        assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1.0)'
+        assert str(local_model.equations[0]) == 'Eq(_environment$time, _environment$time_converted/_0.001)'
+        assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1)'
         assert str(local_model.equations[2]) == 'Eq(Derivative(_env_ode$sv1, _environment$time_converted), ' \
-                                                '1000.0*_env_ode$sv1_orig_deriv)'
+                                                '_env_ode$sv1_orig_deriv/_0.001)'
 
     def test_add_input_literal_variable(self, literals_model):
         """ Tests the Model.convert_variable function that changes units of given variable.
@@ -339,10 +339,10 @@ class TestUnitConversion:
         assert symbol_y.units == literals_model.units.get_unit('per_pA')
         assert symbol_x_orig.units == literals_model.units.get_unit('pA')
         assert len(literals_model.equations) == 4
-        assert str(literals_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
-        assert str(literals_model.equations[1]) == 'Eq(_env_ode$y, _1.0/_env_ode$x)'
-        assert str(literals_model.equations[2]) == 'Eq(_env_ode$x_converted, 0.001*_1.0)'
-        assert str(literals_model.equations[3]) == 'Eq(_env_ode$x, 1000.0*_env_ode$x_converted)'
+        assert str(literals_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
+        assert str(literals_model.equations[1]) == 'Eq(_env_ode$y, _1/_env_ode$x)'
+        assert str(literals_model.equations[2]) == 'Eq(_env_ode$x_converted, _0.001*_1)'
+        assert str(literals_model.equations[3]) == 'Eq(_env_ode$x, _env_ode$x_converted/_0.001)'
 
     def test_add_input_free_variable_multiple(self, multiode_freevar_model):
         """ Tests the Model.convert_variable function that changes units of given variable.
@@ -404,14 +404,14 @@ class TestUnitConversion:
         symbol_derv_y = multiode_freevar_model.get_variable_by_name('env_ode$y_orig_deriv')
         assert symbol_derv_y.units == mV / ms
         assert len(multiode_freevar_model.equations) == 5
-        assert str(multiode_freevar_model.equations[0]) == 'Eq(_environment$time, 1000.0*_environment$time_converted)'
-        assert str(multiode_freevar_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1.0)'
+        assert str(multiode_freevar_model.equations[0]) == 'Eq(_environment$time, _environment$time_converted/_0.001)'
+        assert str(multiode_freevar_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1)'
         assert str(multiode_freevar_model.equations[2]) == 'Eq(Derivative(_env_ode$sv1, ' \
                                                            '_environment$time_converted), ' \
-                                                           '1000.0*_env_ode$sv1_orig_deriv)'
-        assert str(multiode_freevar_model.equations[3]) == 'Eq(_env_ode$y_orig_deriv, _2.0)'
+                                                           '_env_ode$sv1_orig_deriv/_0.001)'
+        assert str(multiode_freevar_model.equations[3]) == 'Eq(_env_ode$y_orig_deriv, _2)'
         assert str(multiode_freevar_model.equations[4]) == 'Eq(Derivative(_env_ode$y, _environment$time_converted), ' \
-                                                           '1000.0*_env_ode$y_orig_deriv)'
+                                                           '_env_ode$y_orig_deriv/_0.001)'
 
     def test_multiple_odes(self, multiode_model):
         """ Tests the Model.convert_variable function that changes units of given variable.
@@ -458,12 +458,12 @@ class TestUnitConversion:
         # change mV to V
         multiode_model.convert_variable(original_var, volt_unit, DataDirectionFlow.INPUT)
         assert len(multiode_model.equations) == 5
-        assert str(multiode_model.equations[0]) == 'Eq(Derivative(_env_ode$y, _environment$time), _2.0)'
-        assert str(multiode_model.equations[1]) == 'Eq(_env_ode$sv1, 1000.0*_env_ode$sv1_converted)'
-        assert str(multiode_model.equations[2]) == 'Eq(_env_ode$sv1_orig_deriv, _1.0)'
+        assert str(multiode_model.equations[0]) == 'Eq(Derivative(_env_ode$y, _environment$time), _2)'
+        assert str(multiode_model.equations[1]) == 'Eq(_env_ode$sv1, _env_ode$sv1_converted/_0.001)'
+        assert str(multiode_model.equations[2]) == 'Eq(_env_ode$sv1_orig_deriv, _1)'
         assert str(multiode_model.equations[3]) == 'Eq(Derivative(_env_ode$sv1_converted, _environment$time), ' \
-                                                   '0.001*_env_ode$sv1_orig_deriv)'
-        assert str(multiode_model.equations[4]) == 'Eq(_env_ode$x, _1.0 + _3.0*_env_ode$sv1_orig_deriv)'
+                                                   '_0.001*_env_ode$sv1_orig_deriv)'
+        assert str(multiode_model.equations[4]) == 'Eq(_env_ode$x, _1 + _3*_env_ode$sv1_orig_deriv)'
 
     def test_multiple_odes_1(self, multiode_model):
         """ Tests the Model.convert_variable function that changes units of given variable.
@@ -515,14 +515,14 @@ class TestUnitConversion:
         # change ms to s
         multiode_model.convert_variable(original_var, second_unit, DataDirectionFlow.INPUT)
         assert len(multiode_model.equations) == 6
-        assert str(multiode_model.equations[0]) == 'Eq(_environment$time, 1000.0*_environment$time_converted)'
-        assert str(multiode_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1.0)'
+        assert str(multiode_model.equations[0]) == 'Eq(_environment$time, _environment$time_converted/_0.001)'
+        assert str(multiode_model.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv, _1)'
         assert str(multiode_model.equations[2]) == 'Eq(Derivative(_env_ode$sv1, _environment$time_converted), ' \
-                                                   '1000.0*_env_ode$sv1_orig_deriv)'
-        assert str(multiode_model.equations[3]) == 'Eq(_env_ode$y_orig_deriv, _2.0)'
+                                                   '_env_ode$sv1_orig_deriv/_0.001)'
+        assert str(multiode_model.equations[3]) == 'Eq(_env_ode$y_orig_deriv, _2)'
         assert str(multiode_model.equations[4]) == 'Eq(Derivative(_env_ode$y, _environment$time_converted), ' \
-                                                   '1000.0*_env_ode$y_orig_deriv)'
-        assert str(multiode_model.equations[5]) == 'Eq(_env_ode$x, _1.0 + _3.0*_env_ode$sv1_orig_deriv)'
+                                                   '_env_ode$y_orig_deriv/_0.001)'
+        assert str(multiode_model.equations[5]) == 'Eq(_env_ode$x, _1 + _3*_env_ode$sv1_orig_deriv)'
 
         # test the graph forming and get_state_variables still works
         states = multiode_model.get_state_variables()
@@ -588,10 +588,10 @@ class TestUnitConversion:
         assert symbol_y.units == literals_model.units.get_unit('per_pA')
         assert symbol_x_orig.units == literals_model.units.get_unit('pA')
         assert len(literals_model.equations) == 4
-        assert str(literals_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
-        assert str(literals_model.equations[1]) == 'Eq(_env_ode$x, _1.0)'
-        assert str(literals_model.equations[2]) == 'Eq(_env_ode$y, _1.0/_env_ode$x)'
-        assert str(literals_model.equations[3]) == 'Eq(_env_ode$x_converted, 0.001*_env_ode$x)'
+        assert str(literals_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
+        assert str(literals_model.equations[1]) == 'Eq(_env_ode$x, _1)'
+        assert str(literals_model.equations[2]) == 'Eq(_env_ode$y, _1/_env_ode$x)'
+        assert str(literals_model.equations[3]) == 'Eq(_env_ode$x_converted, _0.001*_env_ode$x)'
         state_variables = literals_model.get_state_variables()
         assert len(state_variables) == 1
         assert symbol_a in state_variables
@@ -640,8 +640,8 @@ class TestUnitConversion:
         assert symbol_orig.units == local_model.units.get_unit('mV')
         assert symbol_orig.initial_value == 2.0
         assert len(local_model.equations) == 2
-        assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
-        assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_converted, 0.001*_env_ode$sv1)'
+        assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
+        assert str(local_model.equations[1]) == 'Eq(_env_ode$sv1_converted, _0.001*_env_ode$sv1)'
         state_variables = local_model.get_state_variables()
         assert len(state_variables) == 1
         assert symbol_orig in state_variables
@@ -691,8 +691,8 @@ class TestUnitConversion:
         symbol_orig = local_model.get_variable_by_name('environment$time')
         assert symbol_orig.units == local_model.units.get_unit('ms')
         assert len(local_model.equations) == 2
-        assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
-        assert str(local_model.equations[1]) == 'Eq(_environment$time_converted, 0.001*_environment$time)'
+        assert str(local_model.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
+        assert str(local_model.equations[1]) == 'Eq(_environment$time_converted, _0.001*_environment$time)'
         state_variables = local_model.get_state_variables()
         assert len(state_variables) == 1
         assert symbol_a in state_variables
@@ -763,7 +763,7 @@ class TestUnitConversion:
             assert silly_names.get_variable_by_name('env_ode$sv1_converted')
             assert silly_names.get_variable_by_name('env_ode$sv1_orig_deriv')
             assert len(silly_names.equations) == 1
-            assert str(silly_names.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1.0)'
+            assert str(silly_names.equations[0]) == 'Eq(Derivative(_env_ode$sv1, _environment$time), _1)'
             state_variables = silly_names.get_state_variables()
             assert len(state_variables) == 1
             assert symbol_a in state_variables
@@ -792,7 +792,7 @@ class TestUnitConversion:
         assert symbol_derv.units == silly_names.units.get_unit('mV') / silly_names.units.get_unit('ms')
         assert symbol_derv.initial_value is None
         assert len(silly_names.equations) == 3
-        assert str(silly_names.equations[0]) == 'Eq(_env_ode$sv1, 1000.0*_env_ode$sv1_converted_a)'
-        assert str(silly_names.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv_a, _1.0)'
+        assert str(silly_names.equations[0]) == 'Eq(_env_ode$sv1, _env_ode$sv1_converted_a/_0.001)'
+        assert str(silly_names.equations[1]) == 'Eq(_env_ode$sv1_orig_deriv_a, _1)'
         assert str(silly_names.equations[2]) == 'Eq(Derivative(_env_ode$sv1_converted_a, _environment$time), ' \
-                                                '0.001*_env_ode$sv1_orig_deriv_a)'
+                                                '_0.001*_env_ode$sv1_orig_deriv_a)'

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -460,7 +460,7 @@ class TestConvertingExpressions:
     def test_variable_conversion(self, store, cm):
         x = VariableDummy('x', store.get_unit('metre'))
         new_x = store.convert_expression_recursively(x, cm)
-        assert str(new_x) == '_100.0*_x'
+        assert str(new_x) == '_100*_x'
         assert new_x.args[1] is x
         assert isinstance(new_x.args[0], NumberDummy)
         assert new_x.args[0].units == cm / store.get_unit('metre')
@@ -505,7 +505,7 @@ class TestConvertingExpressions:
         expr = sp.Derivative(x, t)
 
         new_expr = store.convert_expression_recursively(expr, cm / t.units)
-        assert str(new_expr) == '_100.0*Derivative(_x, _t)'
+        assert str(new_expr) == '_100*Derivative(_x, _t)'
         assert new_expr.args[0].args[0] is x
         assert new_expr.args[0].args[1][0] is t
 
@@ -523,7 +523,7 @@ class TestConvertingExpressions:
 
         # With conversion
         new_expr = store.convert_expression_recursively(expr, store.get_unit('metre') / store.get_unit('second'))
-        assert str(new_expr) == '_10.0*_x/_y'
+        assert str(new_expr) == '_10*_x/_y'
         assert new_expr.args[2] is x
         assert new_expr.args[0].args[0] is y
 
@@ -532,7 +532,7 @@ class TestConvertingExpressions:
         _2 = NumberDummy('2000', ms)
         expr = x ** (_4 / _2)
         new_expr = store.convert_expression_recursively(expr, None)
-        assert str(new_expr) == '_x**(_1000.0*_4/_2000)'
+        assert str(new_expr) == '_x**(_1000*_4/_2000)'
 
         # With a base that needs internal conversion
         expr = (y + _4) ** 2
@@ -551,7 +551,7 @@ class TestConvertingExpressions:
         x = VariableDummy('x', store.get_unit('second') ** 2)
         expr = x ** (1 / 2)
         new_expr = store.convert_expression_recursively(expr, ms)
-        assert str(new_expr) == '_1000.0*_x**0.5'
+        assert str(new_expr) == '_1000*_x**0.5'
         assert new_expr.args[0].args[0] is x
 
     def test_add_and_subtract(self, store, ms, microsecond):
@@ -566,10 +566,10 @@ class TestConvertingExpressions:
         # If we don't specify units, the first argument (y in canonical form) is chosen
         expr = z + x - y
         new_expr = store.convert_expression_recursively(expr, None)
-        assert str(new_expr) == '_0.001*_z + _1000.0*_x - _y'
+        assert str(new_expr) == '_0.001*_z + _1000*_x - _y'
 
         new_expr = store.convert_expression_recursively(expr, microsecond)
-        assert str(new_expr) == '-_1000.0*_y + _1000000.0*_x + _z'
+        assert str(new_expr) == '-_1000*_y + _1e+06*_x + _z'
 
     def test_abs_ceil_floor(self, store, ms):
         x = VariableDummy('x', store.get_unit('second'))
@@ -581,7 +581,7 @@ class TestConvertingExpressions:
         expr = sp.Abs(x)
         new_expr = store.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.Abs)
-        assert str(new_expr) == 'Abs(_1000.0*_x)'
+        assert str(new_expr) == 'Abs(_1000*_x)'
         assert new_expr.args[0].args[1] is x
 
         expr = sp.floor(x)
@@ -591,13 +591,13 @@ class TestConvertingExpressions:
         expr = sp.floor(x)
         new_expr = store.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.floor)
-        assert str(new_expr) == 'floor(_1000.0*_x)'
+        assert str(new_expr) == 'floor(_1000*_x)'
         assert new_expr.args[0].args[1] is x
 
         expr = sp.ceiling(x)
         new_expr = store.convert_expression_recursively(expr, ms)
         assert isinstance(new_expr, sp.ceiling)
-        assert str(new_expr) == 'ceiling(_1000.0*_x)'
+        assert str(new_expr) == 'ceiling(_1000*_x)'
         assert new_expr.args[0].args[1] is x
 
     def test_exp_log_trig(self, store, ms):
@@ -612,7 +612,7 @@ class TestConvertingExpressions:
         expr = sp.log(y / z)
         new_expr = store.convert_expression_recursively(expr, None)
         assert isinstance(new_expr, sp.log)
-        assert str(new_expr) == 'log(_1000.0*_y/_z)'
+        assert str(new_expr) == 'log(_1000*_y/_z)'
 
         expr = sp.sin(z / y)
         new_expr = store.convert_expression_recursively(expr, dimensionless)
@@ -630,7 +630,7 @@ class TestConvertingExpressions:
 
         expr = z > y
         new_expr = store.convert_expression_recursively(expr, store.get_unit('dimensionless'))
-        assert str(new_expr) == '_z > _1000.0*_y'
+        assert str(new_expr) == '_z > _1000*_y'
 
         # Case with no conversion
         expr = x < z
@@ -659,7 +659,7 @@ class TestConvertingExpressions:
         # Units of result are specified
         new_expr = store.convert_expression_recursively(expr, ms)
         assert str(new_expr) == (
-            'Piecewise((_1000.0*_y, (_2 < _x) & (_y < _0.001*_z)), (_z, _2 > _x), (_2*_z, True))')
+            'Piecewise((_1000*_y, (_2 < _x) & (_y < _0.001*_z)), (_z, _2 > _x), (_2*_z, True))')
 
         # A simpler case with no conversion
         _1 = NumberDummy('1', ms)
@@ -689,7 +689,7 @@ class TestConvertingExpressions:
         expr = a + b
         assert str(expr) == '_10 + _20'
         units, new_expr = store.evaluate_units_and_fix(expr)
-        assert str(new_expr) == '_10 + _1000.0*_20'
+        assert str(new_expr) == '_10 + _1000*_20'
         assert units is ms
 
     def test_evaluate_units_and_fix_with_variable(self, store, ms):
@@ -698,7 +698,7 @@ class TestConvertingExpressions:
         expr = a + b
         assert str(expr) == '_10 + _b'
         units, new_expr = store.evaluate_units_and_fix(expr)
-        assert str(new_expr) == '_10 + _1000.0*_b'
+        assert str(new_expr) == '_10 + _1000*_b'
         assert units is ms
 
     # Methods below check error cases


### PR DESCRIPTION
## Description, motivation and Context

I spotted while doing #276 that `connect_variables` used a `NumberDummy` for the conversion factor but `convert_variable` did not. This PR updates `convert_variable` to address that anomaly.

As part of this, to make the new `NumberDummy` objects print nicely, I changed how their names are determined, which changed test results looking at the string value of expressions.

I've also made the typing of the value more consistent. The `_value` property now stores the value passed to the constructor, and conversion to `float` or `str` or `Float` is only done when calling `float(dummy)` or `str(dummy)` or `.evalf()` respectively.

The old `value` property has gone so users must be explicit about the type they want. If you were using it directly you'll need to update your code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (**breaking** change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [x] Testing is done automatically and codecov shows test coverage
