### PR TITLE
rdf identity without $

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -683,7 +683,7 @@ class Model(object):
             return
 
         # Create new cmeta id
-        cmeta_id = str(variable)
+        cmeta_id = self.get_display_name(variable)
         while self.has_cmeta_id(cmeta_id):
             cmeta_id += '_'
 

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -242,7 +242,7 @@ def test_add_cmeta_id():
     assert v.rdf_identity is None
     model.add_cmeta_id(v)
     assert v.rdf_identity is not None
-    assert v.rdf_identity == '#circle_x__x'
+    assert str(v.rdf_identity) == '#circle_x__x'
 
     # Test on variable with a cmeta id
     v = model.get_variable_by_ontology_term((shared.OXMETA, 'time'))

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -242,6 +242,7 @@ def test_add_cmeta_id():
     assert v.rdf_identity is None
     model.add_cmeta_id(v)
     assert v.rdf_identity is not None
+    assert v.rdf_identity == '#circle_x__x'
 
     # Test on variable with a cmeta id
     v = model.get_variable_by_ontology_term((shared.OXMETA, 'time'))


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed the way model.add_cmeta_id(var) determines what to use as cmeta_id to using display_name

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
According to [https://www.w3.org/TR/xml11/#NT-Nam](https://www.w3.org/TR/xml11/#NT-Name) the `$` carachter is not allowed in IDs
using the display_name function gets a consitent name, in fact the string version with $ replaced since there is no metadata (else there would have been a cmeta_id)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

n/a

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

