### PR TITLE
removed unneeded line

### DIFF
--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -803,7 +803,6 @@ class Model(object):
             # No conversion necessary. The method above will ensure a factor close to 1 is returned as 1.
             return original_variable
         # Make the conversion factor a number symbol with explicit units
-        cf = self.create_quantity(cf, units / original_variable.units)
 
         # Store original state and free symbols (these might change, so need to store references early)
         state_symbols = self.get_state_variables()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

I removed the line `cf = self.create_quantity(cf, units / original_variable.units)` from the convert function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

It doesn't seem needed and was causing issues in chaste_codegen

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

Also tested chaste_codegen with the change
