### PR TITLE
changing import/call for Mul to remove sympy 1.6 depricated warning

### DIFF
--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -267,9 +267,9 @@ class UnitStore(object):
         cf = self.convert(1 * from_unit, to_unit).magnitude
         if isinstance(cf, numbers.Number) and math.isclose(cf, 1.0):
             return 1
-        elif isinstance(cf, sympy.mul.Mul) and 1.0 in cf.args:
+        elif isinstance(cf, sympy.Mul) and 1.0 in cf.args:
             # We get an ugly artefact whereby pint gives us a 1.0*cf as conversion factor; remove the 1.0
-            return sympy.mul.Mul(*[a for a in cf.args if a != 1.0])
+            return sympy.Mul(*[a for a in cf.args if a != 1.0])
         return cf
 
     def convert(self, quantity, unit):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
changed from using sympy.mul.Mul to sympy.Mul as it removed the sympy 1.6 deprecated warning and still works in sympy 1.5 as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

Don't like deprecated warnings as it indicates our code might break at some point in the near future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

n/a

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

As you can see: no warnings
