### PR TITLE
Support for secondary trig functions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Improved support for secondary trigonometric functions such as sec and acoth (PR#314).
+
 # Release 0.2.0
 - Speed of parsing CellML models has been improved by reorganising connection processing. (PR#303)
 - Removed `Model.connect_variables` as it is no longer needed by the parser. (PR#303)

--- a/cellmlmanip/printer.py
+++ b/cellmlmanip/printer.py
@@ -85,6 +85,22 @@ class Printer(sympy.printing.printer.Printer):
         'tan': 'math.tan',
         'tanh': 'math.tanh'
     }
+    _extra_trig_names = {
+        'sec': 'math.cos',
+        'csc': 'math.sin',
+        'cot': 'math.tan',
+        'sech': 'math.cosh',
+        'csch': 'math.sinh',
+        'coth': 'math.tanh',
+    }
+    _extra_inverse_trig_names = {
+        'asec': 'math.acos',
+        'acsc': 'math.asin',
+        'acot': 'math.atan',
+        'asech': 'math.acosh',
+        'acsch': 'math.asinh',
+        'acoth': 'math.atanh',
+    }
 
     # Dictionary mapping Sympy literals to strings for output.
     _literal_names = {
@@ -202,12 +218,23 @@ class Printer(sympy.printing.printer.Printer):
         # Convert arguments
         args = self._bracket_args(expr.args, 0)
 
-        if name in self._function_names:
-            name = self._function_names[name]
-        else:
-            raise ValueError('Unsupported function: ' + str(name))
+        # Normal function
+        func = self._function_names.get(name, None)
+        if func is not None:
+            return func + '(' + args + ')'
 
-        return name + '(' + args + ')'
+        # Secondary trig function (e.g. secant)
+        func = self._extra_trig_names.get(name, None)
+        if func is not None:
+            return '1 / ' + func + '(' + args + ')'
+
+        # Inverse of secondary trig function (e.g. arcsecant)
+        func = self._extra_inverse_trig_names.get(name, None)
+        if func is not None:
+            return func + '(1 / ' + args + ')'
+
+        # Unknown function
+        raise ValueError('Unsupported function: ' + str(name))
 
     def _print_int(self, expr):
         """ Handles python ``int``s. """

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -151,22 +151,43 @@ class TestPrinter(object):
     def test_trig_functions(self, p, x):
 
         # Trig functions
-        assert p.doprint(sp.acos(x)) == 'math.acos(x)'
-        assert p.doprint(sp.acosh(x)) == 'math.acosh(x)'
-        assert p.doprint(sp.asin(x)) == 'math.asin(x)'
-        assert p.doprint(sp.asinh(x)) == 'math.asinh(x)'
-        assert p.doprint(sp.atan(x)) == 'math.atan(x)'
-        assert p.doprint(sp.atanh(x)) == 'math.atanh(x)'
-        assert p.doprint(sp.ceiling(x)) == 'math.ceil(x)'
+        assert p.doprint(sp.sin(x)) == 'math.sin(x)'
         assert p.doprint(sp.cos(x)) == 'math.cos(x)'
+        assert p.doprint(sp.tan(x)) == 'math.tan(x)'
+
+        assert p.doprint(sp.asin(x)) == 'math.asin(x)'
+        assert p.doprint(sp.acos(x)) == 'math.acos(x)'
+        assert p.doprint(sp.atan(x)) == 'math.atan(x)'
+
+        assert p.doprint(sp.sinh(x)) == 'math.sinh(x)'
         assert p.doprint(sp.cosh(x)) == 'math.cosh(x)'
+        assert p.doprint(sp.tanh(x)) == 'math.tanh(x)'
+
+        assert p.doprint(sp.asinh(x)) == 'math.asinh(x)'
+        assert p.doprint(sp.acosh(x)) == 'math.acosh(x)'
+        assert p.doprint(sp.atanh(x)) == 'math.atanh(x)'
+
+        assert p.doprint(sp.sec(x)) == '1 / math.cos(x)'
+        assert p.doprint(sp.csc(x)) == '1 / math.sin(x)'
+        assert p.doprint(sp.cot(x)) == '1 / math.tan(x)'
+
+        assert p.doprint(sp.asec(x)) == 'math.acos(1 / x)'
+        assert p.doprint(sp.acsc(x)) == 'math.asin(1 / x)'
+        assert p.doprint(sp.acot(x)) == 'math.atan(1 / x)'
+
+        assert p.doprint(sp.sech(x)) == '1 / math.cosh(x)'
+        assert p.doprint(sp.csch(x)) == '1 / math.sinh(x)'
+        assert p.doprint(sp.coth(x)) == '1 / math.tanh(x)'
+
+        assert p.doprint(sp.asech(x)) == 'math.acosh(1 / x)'
+        assert p.doprint(sp.acsch(x)) == 'math.asinh(1 / x)'
+        assert p.doprint(sp.acoth(x)) == 'math.atanh(1 / x)'
+
+    def test_functions(self, p, x):
+        assert p.doprint(sp.ceiling(x)) == 'math.ceil(x)'
         assert p.doprint(sp.factorial(x)) == 'math.factorial(x)'
         assert p.doprint(sp.floor(x)) == 'math.floor(x)'
         assert p.doprint(sp.log(x)) == 'math.log(x)'
-        assert p.doprint(sp.sin(x)) == 'math.sin(x)'
-        assert p.doprint(sp.sinh(x)) == 'math.sinh(x)'
-        assert p.doprint(sp.tan(x)) == 'math.tan(x)'
-        assert p.doprint(sp.tanh(x)) == 'math.tanh(x)'
 
     def test_conditions(self, p, x, y, z):
 

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -263,12 +263,37 @@ class TestTranspiler(object):
                           [sympy.Max(sympy.Symbol('a'), sympy.Symbol('b'))])
 
     def test_trig(self):
-        self.assert_equal('<apply><cos/><ci>x</ci></apply>',
-                          [sympy.cos(sympy.Symbol('x'))])
-        self.assert_equal('<apply><sin/><ci>x</ci></apply>',
-                          [sympy.sin(sympy.Symbol('x'))])
-        self.assert_equal('<apply><arctanh/><ci>x</ci></apply>',
-                          [sympy.atanh(sympy.Symbol('x'))])
+        self.assert_equal('<apply><sin/><ci>x</ci></apply>', [sympy.sin(sympy.Symbol('x'))])
+        self.assert_equal('<apply><cos/><ci>x</ci></apply>', [sympy.cos(sympy.Symbol('x'))])
+        self.assert_equal('<apply><tan/><ci>x</ci></apply>', [sympy.tan(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><arcsin/><ci>x</ci></apply>', [sympy.asin(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arccos/><ci>x</ci></apply>', [sympy.acos(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arctan/><ci>x</ci></apply>', [sympy.atan(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><sinh/><ci>x</ci></apply>', [sympy.sinh(sympy.Symbol('x'))])
+        self.assert_equal('<apply><cosh/><ci>x</ci></apply>', [sympy.cosh(sympy.Symbol('x'))])
+        self.assert_equal('<apply><tanh/><ci>x</ci></apply>', [sympy.tanh(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><arcsinh/><ci>x</ci></apply>', [sympy.asinh(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arccosh/><ci>x</ci></apply>', [sympy.acosh(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arctanh/><ci>x</ci></apply>', [sympy.atanh(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><sec/><ci>x</ci></apply>', [sympy.sec(sympy.Symbol('x'))])
+        self.assert_equal('<apply><csc/><ci>x</ci></apply>', [sympy.csc(sympy.Symbol('x'))])
+        self.assert_equal('<apply><cot/><ci>x</ci></apply>', [sympy.cot(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><arcsec/><ci>x</ci></apply>', [sympy.asec(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arccsc/><ci>x</ci></apply>', [sympy.acsc(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arccot/><ci>x</ci></apply>', [sympy.acot(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><sech/><ci>x</ci></apply>', [sympy.sech(sympy.Symbol('x'))])
+        self.assert_equal('<apply><csch/><ci>x</ci></apply>', [sympy.csch(sympy.Symbol('x'))])
+        self.assert_equal('<apply><coth/><ci>x</ci></apply>', [sympy.coth(sympy.Symbol('x'))])
+
+        self.assert_equal('<apply><arcsech/><ci>x</ci></apply>', [sympy.asech(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arccsch/><ci>x</ci></apply>', [sympy.acsch(sympy.Symbol('x'))])
+        self.assert_equal('<apply><arccoth/><ci>x</ci></apply>', [sympy.acoth(sympy.Symbol('x'))])
 
     def test_cn_units(self):
         """ Test if the transpiler uses the number_generator to make number objects. """


### PR DESCRIPTION
## Description
Cellmlmanip had partial support for secondary trig functions (sec, csc, cot, and their inverse and hyperbolic functions). This PR adds tests for the cellml-to-sympy transpiler and adds methods to the printer to write expressions to evaluate them (using python's `math` module, which doesn't have these expressions natively)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Documentation checklist
- [x] I have updated all documentation in the code where necessary.
- [x] I have checked spelling in all (new) comments and documentation.
- [x] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage


