### PR TITLE
better support for secondary trig functions in combined expressions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+# (Unreleased)
+- Fixed a rendering issue with secondary trigonometric functions such as sec and acoth (PR#317). This means that for example that 1 / sec(x) now rencers as cos(x) instead of 1 / 1 / cos(x).
+
 # Release 0.2.1
 - Improved support for secondary trigonometric functions such as sec and acoth (PR#314).
 

--- a/cellmlmanip/printer.py
+++ b/cellmlmanip/printer.py
@@ -106,9 +106,7 @@ class Printer(sympy.printing.printer.Printer):
     }
 
     # The optimisations to apply to an expr to rewrite extra trig functions
-    _optims = []
-    for k, v in _extra_trig.items():
-        _optims.append(ReplaceOptim(k, v))
+    _optims = [ReplaceOptim(k, v) for k, v in _extra_trig.items()]
 
     # Dictionary mapping Sympy literals to strings for output.
     _literal_names = {

--- a/cellmlmanip/printer.py
+++ b/cellmlmanip/printer.py
@@ -144,6 +144,9 @@ class Printer(sympy.printing.printer.Printer):
         """
         expr_prec = precedence(expr)
         parent_prec = parent_precedence
+        # Some equations are substituted for expr. of lower precedence
+        # For example x**-1 is printed as 1/x. An example where this would give na issue is 2**cos(x)**-1
+        # Which should print as 2**(1 / math.cos(x))
         # Adjust precedence to put brackets around 1/x if necessary
         if isinstance(expr, sympy.Pow) and expr.is_commutative and \
                 (-expr.exp is sympy.S.Half or -expr.exp is sympy.S.One):

--- a/cellmlmanip/printer.py
+++ b/cellmlmanip/printer.py
@@ -133,7 +133,7 @@ class Printer(sympy.printing.printer.Printer):
         """Returns printer's representation for expr (as a string)"""
         if isinstance(expr, sympy.Expr):
             expr = optimize(expr, self._optims)
-        return super()._print(expr)
+        return super().doprint(expr)
 
     def _bracket(self, expr, parent_precedence):
         """

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -183,6 +183,23 @@ class TestPrinter(object):
         assert p.doprint(sp.acsch(x)) == 'math.asinh(1 / x)'
         assert p.doprint(sp.acoth(x)) == 'math.atanh(1 / x)'
 
+        assert p.doprint(1 / sp.sec(x)) == 'math.cos(x)'
+        assert p.doprint(1 / sp.sec(x)) == 'math.cos(x)'
+        assert p.doprint(1 / sp.csc(x)) == 'math.sin(x)'
+        assert p.doprint(1 / sp.cot(x)) == 'math.tan(x)'
+
+        assert p.doprint(sp.asec(1 / x)) == 'math.acos(x)'
+        assert p.doprint(sp.acsc(1 / x)) == 'math.asin(x)'
+        assert p.doprint(sp.acot(1 / x)) == 'math.atan(x)'
+
+        assert p.doprint(1 / sp.sech(x)) == 'math.cosh(x)'
+        assert p.doprint(1 / sp.csch(x)) == 'math.sinh(x)'
+        assert p.doprint(1 / sp.coth(x)) == 'math.tanh(x)'
+
+        assert p.doprint(sp.asech(1 / x)) == 'math.acosh(x)'
+        assert p.doprint(sp.acsch(1 / x)) == 'math.asinh(x)'
+        assert p.doprint(sp.acoth(1 / x)) == 'math.atanh(x)'
+
     def test_functions(self, p, x):
         assert p.doprint(sp.ceiling(x)) == 'math.ceil(x)'
         assert p.doprint(sp.factorial(x)) == 'math.factorial(x)'

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -199,9 +199,9 @@ class TestPrinter(object):
         assert p.doprint(sp.asech(1 / x)) == 'math.acosh(x)'
         assert p.doprint(sp.acsch(1 / x)) == 'math.asinh(x)'
         assert p.doprint(sp.acoth(1 / x)) == 'math.atanh(x)'
-        
+
         assert p.doprint(2**sp.sec(x)) == '2**(1 / math.cos(x))'
-        assert p.doprint(5*2**sp.sec(x)) == '5 * 2**(1 / math.cos(x))'
+        assert p.doprint(5 * 2**sp.sec(x)) == '5 * 2**(1 / math.cos(x))'
         assert p.doprint((5 * x)**sp.sec(x)) == '(5 * x)**(1 / math.cos(x))'
 
     def test_functions(self, p, x):

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -199,6 +199,10 @@ class TestPrinter(object):
         assert p.doprint(sp.asech(1 / x)) == 'math.acosh(x)'
         assert p.doprint(sp.acsch(1 / x)) == 'math.asinh(x)'
         assert p.doprint(sp.acoth(1 / x)) == 'math.atanh(x)'
+        
+        assert p.doprint(2**sp.sec(x)) == '2**(1 / math.cos(x))'
+        assert p.doprint(5*2**sp.sec(x)) == '5 * 2**(1 / math.cos(x))'
+        assert p.doprint((5 * x)**sp.sec(x)) == '(5 * x)**(1 / math.cos(x))'
 
     def test_functions(self, p, x):
         assert p.doprint(sp.ceiling(x)) == 'math.ceil(x)'

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -184,7 +184,6 @@ class TestPrinter(object):
         assert p.doprint(sp.acoth(x)) == 'math.atanh(1 / x)'
 
         assert p.doprint(1 / sp.sec(x)) == 'math.cos(x)'
-        assert p.doprint(1 / sp.sec(x)) == 'math.cos(x)'
         assert p.doprint(1 / sp.csc(x)) == 'math.sin(x)'
         assert p.doprint(1 / sp.cot(x)) == 'math.tan(x)'
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes the way secondary trig functions are dealt with. This first transforms them into ordinary trig functions before printing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Fixes #316

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation in the code where necessary.
- [X] I have checked spelling in all (new) comments and documentation.
- [ ] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

