### PR TITLE
sympy 1.7 fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# (Unreleased)
+- Fixes for sympy 1.7: 
+    - Fixed the printer test (eval=false no longer exists but evaluate=false can still be used). 
+    - Removed the positional arguments in Variable as these were causing issues, instead use named arguments for name and units
+
 # Release 0.2.2
 - Fixed a rendering issue with secondary trigonometric functions such as sec and acoth (PR#317). This means for example that 1 / sec(x) now renders as cos(x) instead of 1 / 1 / cos(x).
 

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -1091,12 +1091,12 @@ class Variable(sympy.Dummy):
     """
 
     # Sympy annoyingly overwrites __new__
-    def __new__(cls, name, *args, **kwargs):
-        return super().__new__(cls, name, real=True)
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, real=True)
 
     def __init__(self,
-                 name,
-                 units,
+                 name=None,
+                 units=None,
                  model=None,
                  initial_value=None,
                  public_interface=None,

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -134,7 +134,7 @@ class TestPrinter(object):
         assert p.doprint(sp.sqrt(2)) == 'math.sqrt(2)'
         assert p.doprint(1 / sp.sqrt(2)) == 'math.sqrt(2) / 2'
         assert p.doprint(
-            sp.Mul(1, 1 / sp.sqrt(2), eval=False)) == 'math.sqrt(2) / 2'
+            sp.Mul(1, 1 / sp.sqrt(2), evaluate=False)) == 'math.sqrt(2) / 2'
         assert p.doprint(sp.sqrt(x)) == 'math.sqrt(x)'
         assert p.doprint(1 / sp.sqrt(x)) == '1 / math.sqrt(x)'
         assert p.doprint(x**(x / (2 * x))) == 'math.sqrt(x)'

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -866,3 +866,7 @@ class TestConvertingExpressions:
         expr = _10 + _20
         with pytest.raises(UnitConversionError, match='Context: trying to evaluate'):
             store.evaluate_units_and_fix(expr)
+
+    def test_sympy_variable_handle(self, x, y):
+        u = 2.0 * x / y
+        assert sp.solveset(u + 1e7, x) == sp.FiniteSet(-5000000.0 * y)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Fixes for sympy 1.7: 
    - Fixed the printer test (eval=false no longer exists but evaluate=false can still be used). 
    - Removed the positional arguments in Variable as these were causing issues, instead use named arguments for name and units. Added aditional test that creates new Variable using sympy solveset

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Codegen crashes when trying to use sympy 1.7


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation in the code where necessary.
- [X] I have checked spelling in all (new) comments and documentation.
- [X] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

I ran the test suite with sympy 1.4, 1.5, 1.6, 1.6.2, 1.7 and 1.7.1 (all passing)

