### PR TITLE
dropping python 3.5 support

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - name: Check out repository

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+# (Unreleased)
+- Dropped support for python 3.5 as it is end of life.
+
 # Release 0.3.3
 - Minor performance upgrade for `Model.remove_fixable_singularities` using caching on fixing singularites. No functionality changes.
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
 
     packages=find_packages(exclude=('tests', 'docs')),
     include_package_data=True,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         'lxml>=4',
         'networkx>=2.1',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Dropping python 3.5 support.
Also added python 3.10 testing.
I'm suggesting we don't release this immedately, but rather wait to accumulate soem functionality chanegs, since this PR only removed python 3.5 support and doesn't change anything else.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
- Python 3.5 is end of life.
- - github actions doesn't support python 3.5 anymore for automated testing so it would be hard to keep supporting it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [X] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

