### PR TITLE
fixing errors deling with offsets in unit definitions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,9 @@
 - Fixed a bug in the parser where equations in a piecewise containing a boolean caused parsing errors.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
 
+- Fixes errors dealing with demenionless units which have an offset, multiplier or exponent and implements offset units more generally
+  see https://github.com/ModellingWebLab/cellmlmanip/issues/351
+
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10
 - Dropped support for python 3.5 as it is end of life.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 - Fixed a bug in the parser where equations in a piecewise containing a boolean caused parsing errors.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
 
-- Fixes errors dealing with demenionless units which have an offset, multiplier or exponent and implements offset units more generally
+- Fixes errors dealing with dimensionless units which have an offset, multiplier or exponent and added a warbing for other offset units to indicate that these are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
 
 # Release 0.3.4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 - Fixed a bug in the parser where equations in a piecewise containing a boolean caused parsing errors.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
 
-- Fixes errors dealing with dimensionless units which have a multiplier or exponent and added an error for offset units (where the offset is not 0) as those are not supported.
+- Fixed errors dealing with dimensionless units which have a multiplier or exponent, and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
 
 # Release 0.3.4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 - Fixed a bug in the parser where equations in a piecewise containing a boolean caused parsing errors.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
 
-- Fixes errors dealing with dimensionless units which have an offset, multiplier or exponent and added a warbing for other offset units to indicate that these are not supported.
+- Fixes errors dealing with dimensionless units which have a multiplier or exponent and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
 
 # Release 0.3.4

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -253,7 +253,8 @@ class Parser(object):
             if 'multiplier' in unit_element:
                 expr = '(%s * %s)' % (unit_element['multiplier'], expr)
 
-            if 'offset' in unit_element and unit_element['offset'].strip() != '0':
+            if 'offset' in unit_element and (not unit_element['offset'].strip().isnumeric() or
+                                             int(unit_element['offset']) != 0):
                 raise ValueError('Offsets in units are not supported!')
 
             # Collect/add this particular <unit> definition

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -207,8 +207,8 @@ class Parser(object):
 
             # unit is defined in terms of known units - ok to add to model
             if add_now:
-                definition, offset = self._make_pint_unit_definition(unit_name, unit_elements)
-                self.model.units.add_unit(unit_name, definition, offset)
+                definition = self._make_pint_unit_definition(unit_name, unit_elements)
+                self.model.units.add_unit(unit_name, definition)
                 units_found.add(unit_name)
                 iteration = 0
             else:
@@ -230,7 +230,6 @@ class Parser(object):
         """
         full_unit_expr = []
 
-        offset = None
         # For each of the <unit> elements for this unit definition
         for unit_element in unit_attributes:
 
@@ -254,14 +253,14 @@ class Parser(object):
             if 'multiplier' in unit_element:
                 expr = '(%s * %s)' % (unit_element['multiplier'], expr)
 
-            if 'offset' in unit_element:
-                offset = unit_element['offset']
+            if 'offset' in unit_element and unit_element['offset'].strip() != '0':
+                raise ValueError('Offsets in units are not supported!')
 
             # Collect/add this particular <unit> definition
             full_unit_expr.append(expr)
 
         # Join together all the parts of the unit expression and return
-        return '*'.join(full_unit_expr), offset
+        return '*'.join(full_unit_expr)
 
     def _add_components(self, model):
         """

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -207,8 +207,8 @@ class Parser(object):
 
             # unit is defined in terms of known units - ok to add to model
             if add_now:
-                definition = self._make_pint_unit_definition(unit_name, unit_elements)
-                self.model.units.add_unit(unit_name, definition)
+                definition, offset = self._make_pint_unit_definition(unit_name, unit_elements)
+                self.model.units.add_unit(unit_name, definition, offset)
                 units_found.add(unit_name)
                 iteration = 0
             else:
@@ -230,6 +230,7 @@ class Parser(object):
         """
         full_unit_expr = []
 
+        offset = None
         # For each of the <unit> elements for this unit definition
         for unit_element in unit_attributes:
 
@@ -253,11 +254,14 @@ class Parser(object):
             if 'multiplier' in unit_element:
                 expr = '(%s * %s)' % (unit_element['multiplier'], expr)
 
+            if 'offset' in unit_element:
+                offset = unit_element['offset']
+
             # Collect/add this particular <unit> definition
             full_unit_expr.append(expr)
 
         # Join together all the parts of the unit expression and return
-        return '*'.join(full_unit_expr)
+        return '*'.join(full_unit_expr), offset
 
     def _add_components(self, model):
         """

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -293,7 +293,7 @@ class UnitStore(object):
         #  Trying to convert dimensionless gives an error but we can convert to it
         if quantity.units == self._registry.dimensionless:
             quantity, unit = 1 * unit, quantity.units
-            return 1 / quantity.to(unit)
+            return quantity.magnitude / quantity.to(unit)
         return quantity.to(unit)
 
     def add_conversion_rule(self, from_unit, to_unit, rule):

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -168,15 +168,14 @@ class UnitStore(object):
         # To test if this is a dimensionless unit, parse the string as a Quantity and check if it's dimensionless
         quantity = self._registry.parse_expression(expression)
         if quantity.units == self._registry.dimensionless:
-            #  offsets are not supported for dimensionless
+            # offsets are not supported for dimensionless
             if offset is not None:
-                raise NotSupportedErrorOffsetsDimensionless(expression + '; offset: ' + offset)
+                raise OffsetNotSupportedError(expression + '; offset: ' + offset)
             definition = UnitDefinition(qname, '', (), ScaleConverter(quantity.to(self._registry.dimensionless)))
         else:
             definition = qname + '=' + expression
-            #  if we have an offset, add that to the definition now
-            if offset is not None:
-                definition += '; offset: ' + offset
+            if offset is not None:  # just warn and ignore
+                logger.warning('Offsets in unit definitions are not supported and are ignored!')
 
         # Add to registry
         self._registry.define(definition)
@@ -907,7 +906,7 @@ class UnitConversionError(UnitError):
         self.message = 'Cannot convert units from {} to {}'.format(from_units, to_units)
 
 
-class NotSupportedErrorOffsetsDimensionless(UnitError):
+class OffsetNotSupportedError(UnitError):
     """Represents failure to convert between incompatible units.
 
     :param expression: the Sympy expression in which the error occurred

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -174,7 +174,7 @@ class UnitStore(object):
             definition = UnitDefinition(qname, '', (), ScaleConverter(quantity.to(self._registry.dimensionless)))
         else:
             definition = qname + '=' + expression
-            if offset is not None:  # just warn and ignore
+            if offset is not None and offset.strip() != '0':  # just warn and ignore
                 logger.warning('Offsets in unit definitions are not supported and are ignored!')
 
         # Add to registry

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -140,7 +140,7 @@ class UnitStore(object):
         self.Unit = self._registry.Unit
         self.Quantity = self._registry.Quantity
 
-    def add_unit(self, name, expression, offset=None):
+    def add_unit(self, name, expression):
         """Adds a unit called ``name`` to the unit store, as defined by the string ``expression``.
 
         For example::
@@ -168,14 +168,9 @@ class UnitStore(object):
         # To test if this is a dimensionless unit, parse the string as a Quantity and check if it's dimensionless
         quantity = self._registry.parse_expression(expression)
         if quantity.units == self._registry.dimensionless:
-            # offsets are not supported for dimensionless
-            if offset is not None:
-                raise OffsetNotSupportedError(expression + '; offset: ' + offset)
             definition = UnitDefinition(qname, '', (), ScaleConverter(quantity.to(self._registry.dimensionless)))
         else:
             definition = qname + '=' + expression
-            if offset is not None and offset.strip() != '0':  # just warn and ignore
-                logger.warning('Offsets in unit definitions are not supported and are ignored!')
 
         # Add to registry
         self._registry.define(definition)
@@ -904,15 +899,3 @@ class UnitConversionError(UnitError):
     def __init__(self, expression, from_units, to_units):
         self.expression = expression
         self.message = 'Cannot convert units from {} to {}'.format(from_units, to_units)
-
-
-class OffsetNotSupportedError(UnitError):
-    """Represents failure to convert between incompatible units.
-
-    :param expression: the Sympy expression in which the error occurred
-    :param from_unit: the units the expression is in
-    :param to_unit: the units we tried to convert to
-    """
-    def __init__(self, expression):
-        self.expression = expression
-        self.message = 'Offsets for dimensionless units are not supported'

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -140,7 +140,7 @@ class UnitStore(object):
         self.Unit = self._registry.Unit
         self.Quantity = self._registry.Quantity
 
-    def add_unit(self, name, expression):
+    def add_unit(self, name, expression, offset=None):
         """Adds a unit called ``name`` to the unit store, as defined by the string ``expression``.
 
         For example::
@@ -168,9 +168,15 @@ class UnitStore(object):
         # To test if this is a dimensionless unit, parse the string as a Quantity and check if it's dimensionless
         quantity = self._registry.parse_expression(expression)
         if quantity.units == self._registry.dimensionless:
+            #  offsets are not supported for dimensionless
+            if offset is not None:
+                raise NotSupportedErrorOffsetsDimensionless(expression + '; offset: ' + offset)
             definition = UnitDefinition(qname, '', (), ScaleConverter(quantity.to(self._registry.dimensionless)))
         else:
             definition = qname + '=' + expression
+            #  if we have an offset, add that to the definition now
+            if offset is not None:
+                definition += '; offset: ' + offset
 
         # Add to registry
         self._registry.define(definition)
@@ -290,6 +296,10 @@ class UnitStore(object):
         """
         assert isinstance(quantity, self._registry.Quantity)
         assert isinstance(unit, self._registry.Unit)
+        #  Trying to convert dimensionless gives an error but we can convert to it
+        if quantity.units == self._registry.dimensionless:
+            quantity, unit = 1 * unit, quantity.units
+            return 1 / quantity.to(unit)
         return quantity.to(unit)
 
     def add_conversion_rule(self, from_unit, to_unit, rule):
@@ -895,3 +905,15 @@ class UnitConversionError(UnitError):
     def __init__(self, expression, from_units, to_units):
         self.expression = expression
         self.message = 'Cannot convert units from {} to {}'.format(from_units, to_units)
+
+
+class NotSupportedErrorOffsetsDimensionless(UnitError):
+    """Represents failure to convert between incompatible units.
+
+    :param expression: the Sympy expression in which the error occurred
+    :param from_unit: the units the expression is in
+    :param to_unit: the units we tried to convert to
+    """
+    def __init__(self, expression):
+        self.expression = expression
+        self.message = 'Offsets for dimensionless units are not supported'

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -290,7 +290,7 @@ class UnitStore(object):
         """
         assert isinstance(quantity, self._registry.Quantity)
         assert isinstance(unit, self._registry.Unit)
-        #  Trying to convert dimensionless gives an error but we can convert to it
+        #  Trying to convert FROM dimensionless gives an error but we can convert TO it
         if quantity.units == self._registry.dimensionless:
             quantity, unit = 1 * unit, quantity.units
             return quantity.magnitude / quantity.to(unit)

--- a/tests/cellml_files/dimensionless_exp.cellml
+++ b/tests/cellml_files/dimensionless_exp.cellml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
+<!-- CellML 1.0, 5.2.7: The exponent of dimensionless doesn't matter -->
+<model name="unit_conversion_prefix"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <units name="hyper_dimensionless">
+    <unit units="dimensionless" exponent="12" />
+  </units>
+  <component name="A">
+    <variable name="x" units="dimensionless" initial_value="3" public_interface="out" />
+  </component>
+  <component name="B">
+    <variable name="y" units="hyper_dimensionless" public_interface="in" />
+  </component>
+  <connection>
+    <map_components component_1="A" component_2="B" />
+    <map_variables variable_1="x" variable_2="y" />
+  </connection>
+</model>

--- a/tests/cellml_files/dimensionless_multiplier.cellml
+++ b/tests/cellml_files/dimensionless_multiplier.cellml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
+<!-- CellML 1.0, 5.2.7: Dimensionless units can have a multiplier -->
+<model name="unit_conversion_dimensionless_multiplier_1"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <units name="halves">
+    <unit units="dimensionless" multiplier="0.5" />
+  </units>
+  <component name="A">
+    <variable name="x" units="dimensionless" initial_value="1" public_interface="out" />
+  </component>
+  <component name="B">
+    <variable name="y" units="halves" public_interface="in" />
+  </component>
+  <connection>
+    <map_components component_1="A" component_2="B" />
+    <map_variables variable_1="x" variable_2="y" />
+  </connection>
+</model>

--- a/tests/cellml_files/dimensionless_multiplier.cellml
+++ b/tests/cellml_files/dimensionless_multiplier.cellml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
-<!-- CellML 1.0, 5.2.7: Dimensionless units can have a multiplier -->
+<!-- Testing dimensionless unit with multiplier -->
 <model name="unit_conversion_dimensionless_multiplier_1"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <units name="halves">

--- a/tests/cellml_files/dimensionless_multiplier2.cellml
+++ b/tests/cellml_files/dimensionless_multiplier2.cellml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Testing more dimensionless unit with multiplier -->
+<model name="unit_conversion_dimensionless_multiplier_1"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <units name="half_meter">
+    <unit units="meter" multiplier="0.5" />
+  </units>
+</model>

--- a/tests/cellml_files/dimensionless_offset.cellml
+++ b/tests/cellml_files/dimensionless_offset.cellml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
+<!-- CellML 1.0, 5.2.7: Dimensionless units can have an offset -->
+<model name="unit_conversion_dimensionless_offset"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <units name="biggers">
+    <unit units="dimensionless" offset="-1" />
+  </units>
+  <component name="A">
+    <variable name="x" units="dimensionless" initial_value="3" public_interface="out" />
+  </component>
+  <component name="B">
+    <variable name="y" units="biggers" public_interface="in" />
+  </component>
+  <connection>
+    <map_components component_1="A" component_2="B" />
+    <map_variables variable_1="x" variable_2="y" />
+  </connection>
+</model>

--- a/tests/cellml_files/dimensionless_offset.cellml
+++ b/tests/cellml_files/dimensionless_offset.cellml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
-<!-- CellML 1.0, 5.2.7: Dimensionless units can have an offset -->
+<!-- Testing dimensionless unit with offset -->
 <model name="unit_conversion_dimensionless_offset"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <units name="biggers">

--- a/tests/cellml_files/test_offset.cellml
+++ b/tests/cellml_files/test_offset.cellml
@@ -6,13 +6,6 @@
     <unit units="meter" offset="10" />
   </units>
   <component name="A">
-    <variable name="x" units="meter" initial_value="3" public_interface="out" />
+    <variable name="x" units="offsetmeter" initial_value="3" public_interface="out" />
   </component>
-  <component name="B">
-    <variable name="y" units="offsetmeter" public_interface="in" />
-  </component>
-  <connection>
-    <map_components component_1="A" component_2="B" />
-    <map_variables variable_1="x" variable_2="y" />
-  </connection>
 </model>

--- a/tests/cellml_files/test_offset.cellml
+++ b/tests/cellml_files/test_offset.cellml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Testing unit with offset -->
+<!-- cellmlmanip test: error should be raised if non-zero offset is used -->
 <model name="unit_conversion_dimensionless_offset"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <units name="offsetmeter">

--- a/tests/cellml_files/test_offset.cellml
+++ b/tests/cellml_files/test_offset.cellml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
-<!-- CellML 1.0, 5.2.7: Dimensionless units can have an offset -->
+<!-- Testing unit with offset -->
 <model name="unit_conversion_dimensionless_offset"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <units name="offsetmeter">

--- a/tests/cellml_files/test_offset.cellml
+++ b/tests/cellml_files/test_offset.cellml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
+<!-- CellML 1.0, 5.2.7: Dimensionless units can have an offset -->
+<model name="unit_conversion_dimensionless_offset"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <units name="offsetmeter">
+    <unit units="meter" offset="10" />
+  </units>
+  <component name="A">
+    <variable name="x" units="meter" initial_value="3" public_interface="out" />
+  </component>
+  <component name="B">
+    <variable name="y" units="offsetmeter" public_interface="in" />
+  </component>
+  <connection>
+    <map_components component_1="A" component_2="B" />
+    <map_variables variable_1="x" variable_2="y" />
+  </connection>
+</model>

--- a/tests/cellml_files/test_offset_0.cellml
+++ b/tests/cellml_files/test_offset_0.cellml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Testing unit with 0 offset -->
+<!-- cellmlmaniptest: offset of 0 is ignored: does not affect parsing or unit equivalence when connections are made -->
 <model name="unit_conversion_dimensionless_offset"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <units name="offsetmeter">

--- a/tests/cellml_files/test_offset_0.cellml
+++ b/tests/cellml_files/test_offset_0.cellml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
+<!-- CellML 1.0, 5.2.7: Dimensionless units can have an offset -->
+<model name="unit_conversion_dimensionless_offset"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <units name="offsetmeter">
+    <unit units="meter" offset=" 0 " />
+  </units>
+  <component name="A">
+    <variable name="x" units="meter" initial_value="3" public_interface="out" />
+  </component>
+  <component name="B">
+    <variable name="y" units="offsetmeter" public_interface="in" />
+  </component>
+  <connection>
+    <map_components component_1="A" component_2="B" />
+    <map_variables variable_1="x" variable_2="y" />
+  </connection>
+</model>

--- a/tests/cellml_files/test_offset_0.cellml
+++ b/tests/cellml_files/test_offset_0.cellml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
-<!-- CellML 1.0, 5.2.7: Dimensionless units can have an offset -->
+<!-- Testing unit with 0 offset -->
 <model name="unit_conversion_dimensionless_offset"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <units name="offsetmeter">

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -337,8 +337,8 @@ class TestParser(object):
         assert sorted(map(str, model.variables())) == ['A$x', 'B$y']
         dimensionless = model.units.get_unit('dimensionless')
         hyper_dimensionless = model.units.get_unit('hyper_dimensionless')
-        cf1 = model.units.convert(1 * dimensionless, hyper_dimensionless)
-        cf2 = model.units.convert(1 * hyper_dimensionless, dimensionless)
+        cf1 = model.units.convert(1 * dimensionless, hyper_dimensionless).magnitude
+        cf2 = model.units.convert(1 * hyper_dimensionless, dimensionless).magnitude
         assert cf1 == cf2 == 1
 
     def test_dimensionless_multiplier(self):
@@ -346,17 +346,33 @@ class TestParser(object):
         assert sorted(map(str, model.variables())) == ['A$x', 'B$y']
         dimensionless = model.units.get_unit('dimensionless')
         halves = model.units.get_unit('halves')
-        cf1 = model.units.convert(1 * dimensionless, halves)
-        cf2 = model.units.convert(1 * halves, dimensionless)
-        assert cf1 == 1 / cf2, str([cf1, cf2])
+        cf1 = model.units.convert(1 * dimensionless, halves).magnitude
+        cf2 = model.units.convert(1 * halves, dimensionless).magnitude
+        assert cf1 == 2
+        assert cf2 == 0.5
+
+        cf1 = model.units.convert(2 * dimensionless, halves).magnitude
+        cf2 = model.units.convert(2 * halves, dimensionless).magnitude
+        assert cf1 == 2
+        assert cf2 == 0.5
+
+    def test_dimensionless_multiplier2(self):
+        model = load_model('dimensionless_multiplier2.cellml')
+        meter = model.units.get_unit('meter')
+        half_meter = model.units.get_unit('half_meter')
+        cf1 = model.units.convert(2 * meter, half_meter).magnitude
+        cf2 = model.units.convert(3 * half_meter, meter).magnitude
+        assert cf1 == 4.0
+        assert cf2 == 1.5
 
     def test_dimensionless_offset(self):
         with pytest.raises(ValueError):
             load_model('dimensionless_offset.cellml')
 
     def test_offset(self, caplog):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as value_info:
             load_model('test_offset.cellml')
+        assert 'Offsets in units are not supported!' in str(value_info)
 
     def test_offset_0(self, caplog):
         model = load_model('test_offset_0.cellml')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -362,3 +362,11 @@ class TestParser(object):
         meter = model.units.get_unit('meter')
         offsetmeter = model.units.get_unit('offsetmeter')
         assert model.units.is_equivalent(meter, offsetmeter)
+
+    def test_offset_0(self, caplog):
+        model = load_model('test_offset_0.cellml')
+        assert 'Offsets in unit definitions are not supported and are ignored!' not in caplog.text
+        assert sorted(map(str, model.variables())) == ['A$x', 'B$y']
+        meter = model.units.get_unit('meter')
+        offsetmeter = model.units.get_unit('offsetmeter')
+        assert model.units.is_equivalent(meter, offsetmeter)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -351,11 +351,6 @@ class TestParser(object):
         assert cf1 == 2
         assert cf2 == 0.5
 
-        cf1 = model.units.convert(2 * dimensionless, halves).magnitude
-        cf2 = model.units.convert(2 * halves, dimensionless).magnitude
-        assert cf1 == 2
-        assert cf2 == 0.5
-
     def test_dimensionless_multiplier2(self):
         model = load_model('dimensionless_multiplier2.cellml')
         meter = model.units.get_unit('meter')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,6 @@ import pytest
 import sympy
 
 from cellmlmanip import parser
-from cellmlmanip.units import OffsetNotSupportedError
 
 from .shared import check_left_right_units_equal, load_model
 
@@ -352,16 +351,12 @@ class TestParser(object):
         assert cf1 == 1 / cf2, str([cf1, cf2])
 
     def test_dimensionless_offset(self):
-        with pytest.raises(OffsetNotSupportedError):
+        with pytest.raises(ValueError):
             load_model('dimensionless_offset.cellml')
 
     def test_offset(self, caplog):
-        model = load_model('test_offset.cellml')
-        assert 'Offsets in unit definitions are not supported and are ignored!' in caplog.text
-        assert sorted(map(str, model.variables())) == ['A$x', 'B$y']
-        meter = model.units.get_unit('meter')
-        offsetmeter = model.units.get_unit('offsetmeter')
-        assert model.units.is_equivalent(meter, offsetmeter)
+        with pytest.raises(ValueError):
+            load_model('test_offset.cellml')
 
     def test_offset_0(self, caplog):
         model = load_model('test_offset_0.cellml')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes errors dealing with:
- offsets in unit definitions (warning if non-0 and not dimensionless)
- offsets in demenionless units (error)
- demenionless units with an exponent
- demenionless units with a multiplier

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
fixes #351

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation in the code where necessary.
- [x] I have checked spelling in all (new) comments and documentation.
- [x] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

