### PR TITLE
added an error for duplicate component names

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # (unreleased)
 - Fixed a bug in the parser where equations in a piecewise containing a boolean caused parsing errors.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
+- Added an error for duplicate component names.
 
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
 - Added an error for duplicate component names.
 
+
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10
 - Dropped support for python 3.5 as it is end of life.

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -273,6 +273,8 @@ class Parser(object):
         for element in component_elements:
             # component are only kept in parser to resolve relationships and connections
             name = element.get('name')
+            if name in self.components:
+                raise ValueError(f'Duplicate component name {name}, component names must be unique!')
             self.components[name] = _Component(name)
 
             # process the <variable> tags in this component

--- a/tests/cellml_files/test_duplicate_component_names.cellml
+++ b/tests/cellml_files/test_duplicate_component_names.cellml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
+<!-- CellML 1.0, 3.4.2.2: Component names must be unique -->
+<model name="component_name_duplicate"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <component name="c1" />
+  <component name="c1" />
+</model>

--- a/tests/cellml_files/test_duplicate_component_names.cellml
+++ b/tests/cellml_files/test_duplicate_component_names.cellml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- CellML Test Suite. https://github.com/MichaelClerx/cellml-validation -->
-<!-- CellML 1.0, 3.4.2.2: Component names must be unique -->
+<!-- Testing duplicate component names -->
 <model name="component_name_duplicate"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <component name="c1" />

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -331,3 +331,7 @@ class TestParser(object):
                 sympy.Eq(Ax, zero)]
         model_eqs = sorted(map(str, model.equations))
         assert model_eqs == sorted(map(str, set(eqs1))) or model_eqs == sorted(map(str, set(eqs2)))
+
+    def test_duplicate_component_name(self):
+        with pytest.raises(ValueError):
+            load_model('test_duplicate_component_names.cellml')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -333,5 +333,6 @@ class TestParser(object):
         assert model_eqs == sorted(map(str, set(eqs1))) or model_eqs == sorted(map(str, set(eqs2)))
 
     def test_duplicate_component_name(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as value_info:
             load_model('test_duplicate_component_names.cellml')
+        assert 'Duplicate component name c1, component names must be unique!' in str(value_info.value)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Throws a ValueError when trying to add a component with a name already in use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Fixes #245

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation in the code where necessary.
- [x] I have checked spelling in all (new) comments and documentation.
- [x] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

