### PR TITLE
improve units in components errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 - Added an error for duplicate component names.
 - Fixed errors dealing with dimensionless units which have a multiplier or exponent, and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
+- Improved error reporting: When a unit is deined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found.
 
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
 - Added an error for duplicate component names.
 - Fixed errors dealing with dimensionless units which have a multiplier or exponent, and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
-- Improved error reporting: When a unit is deined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found.
+- Improved error reporting: When a unit is defined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found.
 
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
 - Added an error for duplicate component names.
 - Fixed errors dealing with dimensionless units which have a multiplier or exponent, and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
-- Improved error reporting: When a unit is defined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found.
+- Improved error reporting: When a unit is defined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found. 
 
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -325,7 +325,17 @@ class Parser(object):
                                                            attributes['name'])
 
             # look up units
-            attributes['units'] = self.model.units.get_unit(attributes['units'])
+            try:
+                attributes['units'] = self.model.units.get_unit(attributes['units'])
+            except KeyError:
+                # Raise error if component units are defined, causing his lookup key error
+                units_in_comp_xpath = with_ns(XmlNs.CELLML, 'component') + '/' + with_ns(XmlNs.CELLML, 'units')
+                units_in_components = component_element.getroottree().getroot().findall(units_in_comp_xpath)
+                if len(units_in_components) != 0:
+                    raise ValueError('Defining units inside components is not supported (found in component ' +
+                                     component_element.get('name') + ').')
+                else:  # else pass on KeyError
+                    raise
 
             # model.add_variable() returns sympy dummy created for this variable - keep it
             variable_lookup_symbol[attributes['name']] = self.model.add_variable(**attributes)

--- a/tests/cellml_files/units_dont_exist.cellml
+++ b/tests/cellml_files/units_dont_exist.cellml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Unit definitions inside components should give an error -->
+<model name="variable_units_component"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <component name="A">
+    <variable name="a" units="oranges" />
+  </component>
+</model>

--- a/tests/cellml_files/units_in_components.cellml
+++ b/tests/cellml_files/units_in_components.cellml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Unit definitions inside components should give an error -->
+<model name="variable_units_component"
+       xmlns="http://www.cellml.org/cellml/1.0#">
+  <component name="A">
+    <units name="oranges">
+      <unit units="volt" />
+    </units>
+    <variable name="a" units="oranges" />
+  </component>
+</model>

--- a/tests/cellml_files/units_in_components2.cellml
+++ b/tests/cellml_files/units_in_components2.cellml
@@ -3,6 +3,15 @@
 <model name="variable_units_component"
        xmlns="http://www.cellml.org/cellml/1.0#">
   <component name="A">
+    <units name="oranges">
+      <unit units="volt" />
+    </units>
     <variable name="a" units="oranges" />
+  </component>
+  <component name="B">
+    <units name="pears">
+      <unit units="volt" />
+    </units>
+    <variable name="b" units="pears" />
   </component>
 </model>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -396,3 +396,8 @@ class TestParser(object):
         with pytest.raises(ValueError) as value_info:
             load_model('test_duplicate_component_names.cellml')
         assert 'Duplicate component name c1, component names must be unique!' in str(value_info.value)
+
+    def test_units_in_components(self):
+        with pytest.raises(ValueError) as value_info:
+            load_model('units_in_components.cellml')
+        assert 'Defining units inside components is not supported (found in component A).' in str(value_info.value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -401,3 +401,8 @@ class TestParser(object):
         with pytest.raises(ValueError) as value_info:
             load_model('units_in_components.cellml')
         assert 'Defining units inside components is not supported (found in component A).' in str(value_info.value)
+
+    def test_units_dont_exist(self):
+        with pytest.raises(KeyError) as value_info:
+            load_model('units_dont_exist.cellml')
+        assert 'Unknown unit <oranges>.' in str(value_info.value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -402,7 +402,7 @@ class TestParser(object):
             load_model('units_in_components.cellml')
         assert 'Defining units inside components is not supported (found in component A).' in str(value_info.value)
 
-    def test_units_dont_exist(self):
-        with pytest.raises(KeyError) as value_info:
-            load_model('units_dont_exist.cellml')
-        assert 'Unknown unit <oranges>.' in str(value_info.value)
+    def test_units_in_components2(self):
+        with pytest.raises(ValueError) as value_info:
+            load_model('units_in_components2.cellml')
+        assert 'Defining units inside components is not supported (found in components A, B).' in str(value_info.value)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Improved error reporting: When a unit is defined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Fixes #358 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation in the code where necessary.
- [x] I have checked spelling in all (new) comments and documentation.
- [x] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

