### PR TITLE
added better errors / warning for booleans in inequalities

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@
 - Fixed errors dealing with dimensionless units which have a multiplier or exponent, and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
 - Improved error reporting: When a unit is defined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found. 
-- Added a better error message for inequalities <, >, <=, >= when one or both sides are a boolan. Added a warning for == and != when one side is a boolean, but not the other.
+- Added a better error message for inequalities <, >, <=, >= when one or both sides are a boolean. Added a warning for == and != when one side is a boolean, but not the other.
 
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - Fixed errors dealing with dimensionless units which have a multiplier or exponent, and added an error for offset units (where the offset is not 0) as those are not supported.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/351
 - Improved error reporting: When a unit is defined inside a component and used it now throws a ValueError indicating units in components are not supported. Previously a confusing KeyError was thrown, which suggested the unit was not found. 
+- Added a better error message for inequalities <, >, <=, >= when one or both sides are a boolan. Added a warning for == and != when one side is a boolean, but not the other.
 
 # Release 0.3.4
 - Updated how substitution of functions that were changed in the parser are handled during analysis for fixing singularities, in order to make sure it workes with sympy 1.10

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -629,6 +629,7 @@ class Model(object):
         :param equation: A :class:`sympy.Eq` object.
         :param check_duplicates: whether to check that the equation's LHS is not already defined
         """
+        print(equation, type(equation))
         assert isinstance(equation, sympy.Eq), 'The argument `equation` must be a sympy.Eq.'
         lhs = equation.lhs
         if lhs.is_Derivative:

--- a/cellmlmanip/model.py
+++ b/cellmlmanip/model.py
@@ -629,7 +629,6 @@ class Model(object):
         :param equation: A :class:`sympy.Eq` object.
         :param check_duplicates: whether to check that the equation's LHS is not already defined
         """
-        print(equation, type(equation))
         assert isinstance(equation, sympy.Eq), 'The argument `equation` must be a sympy.Eq.'
         lhs = equation.lhs
         if lhs.is_Derivative:

--- a/cellmlmanip/parser.py
+++ b/cellmlmanip/parser.py
@@ -735,7 +735,6 @@ class Transpiler(object):
         """https://www.w3.org/TR/MathML2/chapter4.html#contm.apply
         """
         result = self.transpile(node)
-        print(result)
         if len(result) > 1:
             expression = result[0](*(result[1:]))
         else:

--- a/tests/cellml_files/boolean_in_inequality.cellml
+++ b/tests/cellml_files/boolean_in_inequality.cellml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Testing boolans in inequality gives an error -->
+<model name="boolean_compare_geq_operand_error"
+       xmlns="http://www.cellml.org/cellml/1.0#"
+       xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+  <component name="A">
+    <variable name="x" units="dimensionless" />
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <apply>
+        <eq/>
+        <ci>x</ci>
+        <piecewise>
+          <piece>
+            <cn cellml:units="dimensionless">1</cn>
+            <apply>
+              <geq />
+              <cn cellml:units="dimensionless">1</cn>
+              <true />
+            </apply>
+          </piece>
+          <otherwise>
+            <cn cellml:units="dimensionless">0</cn>
+          </otherwise>
+        </piecewise>
+      </apply>
+    </math>
+  </component>
+</model>

--- a/tests/cellml_files/boolean_in_inequality2.cellml
+++ b/tests/cellml_files/boolean_in_inequality2.cellml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Testing boolans in inequality gives an error -->
+<!-- Testing boolans in inequality gives a warning when inequality is !== or == and either side is a boolean but not both-->
 <model name="boolean_compare_geq_operand_error"
        xmlns="http://www.cellml.org/cellml/1.0#"
        xmlns:cellml="http://www.cellml.org/cellml/1.0#">

--- a/tests/cellml_files/boolean_in_inequality2.cellml
+++ b/tests/cellml_files/boolean_in_inequality2.cellml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Testing boolans in inequality gives an error -->
+<model name="boolean_compare_geq_operand_error"
+       xmlns="http://www.cellml.org/cellml/1.0#"
+       xmlns:cellml="http://www.cellml.org/cellml/1.0#">
+  <component name="A">
+    <variable name="x" units="dimensionless" />
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+      <apply>
+        <eq/>
+        <ci>x</ci>
+        <piecewise>
+          <piece>
+            <cn cellml:units="dimensionless">1</cn>
+            <apply>
+              <eq />
+              <cn cellml:units="dimensionless">1</cn>
+              <true />
+            </apply>
+          </piece>
+          <otherwise>
+            <cn cellml:units="dimensionless">0</cn>
+          </otherwise>
+        </piecewise>
+      </apply>
+    </math>
+  </component>
+</model>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -369,7 +369,7 @@ class TestParser(object):
         with pytest.raises(ValueError):
             load_model('dimensionless_offset.cellml')
 
-    def test_offset(self, caplog):
+    def test_offset(self):
         with pytest.raises(ValueError) as value_info:
             load_model('test_offset.cellml')
         assert 'Offsets in units are not supported!' in str(value_info)
@@ -402,7 +402,13 @@ class TestParser(object):
             load_model('units_in_components.cellml')
         assert 'Defining units inside components is not supported (found in component A).' in str(value_info.value)
 
-    def test_units_in_components2(self):
-        with pytest.raises(ValueError) as value_info:
-            load_model('units_in_components2.cellml')
-        assert 'Defining units inside components is not supported (found in components A, B).' in str(value_info.value)
+    def test_boolean_in_inequality(self):
+        with pytest.raises(TypeError) as value_info:
+            load_model('boolean_in_inequality.cellml')
+        assert "Boolean not allowed in inequality: 1.0 <class 'sympy.core.relational.GreaterThan'> True" \
+            in str(value_info.value)
+
+    def test_boolean_in_inequality2(self, caplog):
+        load_model('boolean_in_inequality2.cellml')
+        assert ("WARNING  cellmlmanip.parser:parser.py:933 Boolean used in part of (in)equality equation is this "
+               "intentional?: 1.0 <class 'sympy.core.relational.Equality'> True") in caplog.text

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -410,5 +410,5 @@ class TestParser(object):
 
     def test_boolean_in_inequality2(self, caplog):
         load_model('boolean_in_inequality2.cellml')
-        assert ("WARNING  cellmlmanip.parser:parser.py:933 Boolean used in part of (in)equality equation is this "
-               "intentional?: 1.0 <class 'sympy.core.relational.Equality'> True") in caplog.text
+        assert ("Boolean used in part of (in)equality equation is this intentional?: "
+                "1.0 <class 'sympy.core.relational.Equality'> True") in caplog.text


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a better error message for inequalities <, >, <=, >= when one or both sides are a boolan. Added a warning for == and != when one side is a boolean, but not the other.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
fixes #342 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [ ] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

