### PR TITLE
Update ScaleConverter import

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
-# (unreleased)
+# Relsease 0.3.5
+- Pinned Pint version to be > 0.9 and < 0.20 since 0.20 has changed the location and number of arguments of the ScaleConverter and UnitDefinition classes
 - Fixed a bug in the parser where equations in a piecewise containing a boolean caused parsing errors.
   see https://github.com/ModellingWebLab/cellmlmanip/issues/350
 - Added an error for duplicate unit definitions.

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -13,7 +13,7 @@ from operator import mul
 import pint
 import sympy
 from pint.facets.plain.definitions import ScaleConverter
-from pint.facets.plain.definitions UnitDefinition
+from pint.facets.plain.definitions import UnitDefinition
 from pint.errors import DimensionalityError
 
 from . import model

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -12,9 +12,20 @@ from operator import mul
 
 import pint
 import sympy
-from pint.facets.plain.definitions import ScaleConverter
-from pint.facets.plain.definitions import UnitDefinition
-from pint.errors import DimensionalityError
+try:
+    from pint.facets.plain.definitions import ScaleConverter
+except ModuleNotFoundError:
+    from pint.converters import ScaleConverter
+
+try:
+    from pint.facets.plain.definitions import UnitDefinition
+except ModuleNotFoundError:
+    from pint.definitions import UnitDefinition
+
+try:
+    from pint.errors import DimensionalityError
+except ModuleNotFoundError:
+    from pint.errors import DimensionalityError
 
 from . import model
 

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -12,7 +12,7 @@ from operator import mul
 
 import pint
 import sympy
-from pint.converters import ScaleConverter
+from pint.facets.plain.definitions import ScaleConverter
 from pint.definitions import UnitDefinition
 from pint.errors import DimensionalityError
 

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -13,7 +13,7 @@ from operator import mul
 import pint
 import sympy
 from pint.facets.plain.definitions import ScaleConverter
-from pint.definitions import UnitDefinition
+from pint.facets.plain.definitions UnitDefinition
 from pint.errors import DimensionalityError
 
 from . import model

--- a/cellmlmanip/units.py
+++ b/cellmlmanip/units.py
@@ -12,20 +12,9 @@ from operator import mul
 
 import pint
 import sympy
-try:
-    from pint.facets.plain.definitions import ScaleConverter
-except ModuleNotFoundError:
-    from pint.converters import ScaleConverter
-
-try:
-    from pint.facets.plain.definitions import UnitDefinition
-except ModuleNotFoundError:
-    from pint.definitions import UnitDefinition
-
-try:
-    from pint.errors import DimensionalityError
-except ModuleNotFoundError:
-    from pint.errors import DimensionalityError
+from pint.converters import ScaleConverter
+from pint.definitions import UnitDefinition
+from pint.errors import DimensionalityError
 
 from . import model
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'lxml>=4',
         'networkx>=2.1',
-        'pint>=0.9.0',
+        'Pint>=0.9, <0.20',
         'rdflib>=4',
         'sympy>=1.4',
     ],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Pinned Pint version to be > 0.9 and < 0.20 since 0.20 has changed the location and number of arguments of the ScaleConverter and UnitDefinition classes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Otherwise python 3.10 will pull in an incompatible Pint version

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [x] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

