### PR TITLE
Bumped python version used for readthedocs.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.5
+  version: 3.9
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Description
Updated python version used to generate the docs from 3.5 to 3.9. Didn't go straight to 3.11 because readthedocs had some issues at one point on 3.10 and have not checked 3.11 yet.

## Motivation and Context
Docs don't build on readthedocs and haven't for over a year

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
